### PR TITLE
The spec/fixtures/doc/components directory is not included in the gem

### DIFF
--- a/thor.gemspec
+++ b/thor.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |s|
      "spec/fixtures/bundle/main.thor",
      "spec/fixtures/doc",
      "spec/fixtures/doc/%file_name%.rb.tt",
-     "spec/fixtures/doc/components",
+     "spec/fixtures/doc/components/.empty_directory",
      "spec/fixtures/doc/README",
      "spec/fixtures/group.thor",
      "spec/fixtures/invoke.thor",


### PR DESCRIPTION
This ommision breaks a few specs. I've updated the gemspec to include the dot file instead, thus forcing rubygems to also pack the directory.
