### PR TITLE
Added Thor::Base::ClassMethods.basename.

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -252,8 +252,7 @@ class Thor
       # the namespace should be displayed as arguments.
       #
       def banner(task, namespace = nil, subcommand = false)
-        base = File.basename($0).split(" ").first
-        "#{base} #{task.formatted_usage(self, $thor_runner, subcommand)}"
+        "#{basename} #{task.formatted_usage(self, $thor_runner, subcommand)}"
       end
 
       def baseclass #:nodoc:

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -531,6 +531,13 @@ class Thor
           false
         end
 
+        #
+        # The basename of the program invoking the thor class.
+        #
+        def basename
+          File.basename($0).split(' ').first
+        end
+
         # SIGNATURE: Sets the baseclass. This is where the superclass lookup
         # finishes.
         def baseclass #:nodoc:

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -230,7 +230,7 @@ class Thor::Group
       # The banner for this class. You can customize it if you are invoking the
       # thor class by another ways which is not the Thor::Runner.
       def banner
-        "#{$0} #{self_task.formatted_usage(self, false)}"
+        "#{basename} #{self_task.formatted_usage(self, false)}"
       end
 
       # Represents the whole class as a task.


### PR DESCRIPTION
Added `Thor::Base::ClassMethods.basename`, which is used by both `Thor.banner` and `Thor::Group.banner` for consistencey.
