### PR TITLE
Bug with inside action not respecting pretend mode

### DIFF
--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -162,6 +162,12 @@ describe Thor::Actions do
           runner.say_status :no, :padding
         end.must =~ /no  padding/
       end
+
+      it "remove littered directories in pretend mode" do
+        runner.inside("bar", :pretend => true) {}
+        directory_that_shouldnt_exist = destination_root + "/bar"
+        File.exists?(directory_that_shouldnt_exist).must be_false
+      end
     end
   end
 


### PR DESCRIPTION
Hi Guys,

Please have a look at the pull request on my attempt to fix the issue relating to the inside method not respecting the pretend mode.

The creating directory and then removing it if created within the thor block was suggested by Jose Valim to Rohit and communicated to me via the Rails ticket 5716. I'm not 100% confident if creating and the removing it such a good idea pretend mode should ideally not assume permission to write and then remove exists. Anyway, here's an attempt to get the ball rolling.

Cheers,
Aditya
