### PR TITLE
get action accepts https remote sources

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -51,7 +51,7 @@ class Thor
       config = args.last.is_a?(Hash) ? args.pop : {}
       destination = args.first
 
-      source = File.expand_path(find_in_source_paths(source.to_s)) unless source =~ /^http\:\/\//
+      source = File.expand_path(find_in_source_paths(source.to_s)) unless source =~ /^https?\:\/\//
       render = open(source) {|input| input.binmode.read }
 
       destination ||= if block_given?

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -114,6 +114,15 @@ describe Thor::Actions do
       end
       FakeWeb.clean_registry
     end
+
+    it "accepts https remote sources" do
+      body = "__start__\nHTTPSFILE\n__end__\n"
+      FakeWeb.register_uri(:get, 'https://example.com/file.txt', :body => body)
+      action :get, 'https://example.com/file.txt' do |content|
+        content.must == body
+      end
+      FakeWeb.clean_registry
+    end
   end
 
   describe "#template" do


### PR DESCRIPTION
Hi,

Add support of https remote sources to get action ("because" github is only https now ;)).
