### PR TITLE
Guess the destination from source for template action as per docs.

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -102,7 +102,7 @@ class Thor
     #
     def template(source, *args, &block)
       config = args.last.is_a?(Hash) ? args.pop : {}
-      destination = args.first || source
+      destination = args.first || source.sub(/\.tt$/, '')
 
       source  = File.expand_path(find_in_source_paths(source.to_s))
       context = instance_eval('binding')

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -173,7 +173,7 @@ describe Thor::Actions do
     it "converts enconded instructions" do
       runner.should_receive(:file_name).and_return("rdoc")
       action :template, "doc/%file_name%.rb.tt"
-      file = File.join(destination_root, "doc/rdoc.rb.tt")
+      file = File.join(destination_root, "doc/rdoc.rb")
       File.exists?(file).should be_true
     end
 
@@ -186,6 +186,13 @@ describe Thor::Actions do
         "OMG" + content
       end
       File.read(File.join(destination_root, "doc/config.rb")).should =~ /^OMG/
+    end
+    
+    it "guesses the destination name when given only a source" do
+      action :template, "doc/config.yaml.tt"
+
+      file = File.join(destination_root, "doc/config.yaml")
+      File.exists?(file).should be_true
     end
   end
 

--- a/spec/fixtures/doc/config.yaml.tt
+++ b/spec/fixtures/doc/config.yaml.tt
@@ -1,0 +1,1 @@
+--- Hi from yaml


### PR DESCRIPTION
From thor's documentation:
    Gets an ERB template at the relative source, executes it and makes a copy
    at the relative destination. If the destination is not given it's assumed
    to be equal to the source removing .tt from the filename.

This commit makes thor remove the .tt where appropriate.
Tests are included.
