### PR TITLE
Add Thor::Actions#chown and Thor::Actions#chgrp for Changing File Ownership

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -128,7 +128,7 @@ class Thor
     def chmod(path, mode, config={})
       return unless behavior == :invoke
       path = File.expand_path(path, destination_root)
-      say_status :chmod, relative_to_original_destination_root(path), config.fetch(:verbose, true)
+      say_status :chmod, sprintf("%o %s", mode, relative_to_original_destination_root(path)), config.fetch(:verbose, true)
       FileUtils.chmod_R(mode, path) unless options[:pretend]
     end
 
@@ -147,7 +147,10 @@ class Thor
     def chown(path, user, group, config={})
       return unless behavior == :invoke
       path = File.expand_path(path, destination_root)
-      say_status :chown, relative_to_original_destination_root(path), config.fetch(:verbose, true)
+      message = "#{user}"
+      message << ":#{group}" if group
+      message << " #{relative_to_original_destination_root(path)}"
+      say_status :chown, message, config.fetch(:verbose, true)
       FileUtils.chown_R(user, group, path) unless options[:pretend]
     end
 
@@ -165,7 +168,7 @@ class Thor
     def chgrp(path, group, config={})
       return unless behavior == :invoke
       path = File.expand_path(path, destination_root)
-      say_status :chgrp, relative_to_original_destination_root(path), config.fetch(:verbose, true)
+      say_status :chgrp, "#{group} #{relative_to_original_destination_root(path)}", config.fetch(:verbose, true)
       FileUtils.chown_R(nil, group, path) unless options[:pretend]
     end
 

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -132,6 +132,25 @@ class Thor
       FileUtils.chmod_R(mode, path) unless options[:pretend]
     end
 
+    # Changes the owner and group of the given file or directory.
+    #
+    # ==== Parameters
+    # path<String>:: the name of the file to change owner and group
+    # user<String>:: the user
+    # group<String>:: the group
+    # config<Hash>:: give :verbose => false to not log the status.
+    #
+    # ==== Example
+    #
+    #   chown "script/*", "bob", "admin"
+    #
+    def chown(path, user, group, config={})
+      return unless behavior == :invoke
+      path = File.expand_path(path, destination_root)
+      say_status :chown, relative_to_original_destination_root(path), config.fetch(:verbose, true)
+      FileUtils.chown_R(user, group, path) unless options[:pretend]
+    end
+
     # Prepend text to a file. Since it depends on insert_into_file, it's reversible.
     #
     # ==== Parameters

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -151,6 +151,24 @@ class Thor
       FileUtils.chown_R(user, group, path) unless options[:pretend]
     end
 
+    # Changes the group of the given file or directory.
+    #
+    # ==== Parameters
+    # path<String>:: the name of the file to change group
+    # group<String>:: the group
+    # config<Hash>:: give :verbose => false to not log the status.
+    #
+    # ==== Example
+    #
+    #   chgrp "script/*", "admin"
+    #
+    def chgrp(path, group, config={})
+      return unless behavior == :invoke
+      path = File.expand_path(path, destination_root)
+      say_status :chgrp, relative_to_original_destination_root(path), config.fetch(:verbose, true)
+      FileUtils.chown_R(nil, group, path) unless options[:pretend]
+    end
+
     # Prepend text to a file. Since it depends on insert_into_file, it's reversible.
     #
     # ==== Parameters

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -50,6 +50,29 @@ describe Thor::Actions do
     end
   end
 
+  describe "#chown" do
+    it "executes the command given" do
+      FileUtils.should_receive(:chown_R).with("user", "group", file)
+      action :chown, "foo", "user", "group"
+    end
+
+    it "does not execute the command if pretending given" do
+      FileUtils.should_not_receive(:chown_R)
+      runner(:pretend => true)
+      action :chown, "foo", "user", "group"
+    end
+
+    it "logs status" do
+      FileUtils.should_receive(:chown_R).with("user", "group", file)
+      action(:chown, "foo", "user", "group").should == "       chown  foo\n"
+    end
+
+    it "does not log status if required" do
+      FileUtils.should_receive(:chown_R).with("user", "group", file)
+      action(:chown, "foo", "user", "group", :verbose => false).should be_empty
+    end
+  end
+
   describe "#copy_file" do
     it "copies file from source to default destination" do
       action :copy_file, "task.thor"

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -73,6 +73,29 @@ describe Thor::Actions do
     end
   end
 
+  describe "#chgrp" do
+    it "executes the command given" do
+      FileUtils.should_receive(:chown_R).with(nil, "group", file)
+      action :chgrp, "foo", "group"
+    end
+
+    it "does not execute the command if pretending given" do
+      FileUtils.should_not_receive(:chown_R)
+      runner(:pretend => true)
+      action :chgrp, "foo", "group"
+    end
+
+    it "logs status" do
+      FileUtils.should_receive(:chown_R).with(nil, "group", file)
+      action(:chgrp, "foo", "group").should == "       chgrp  foo\n"
+    end
+
+    it "does not log status if required" do
+      FileUtils.should_receive(:chown_R).with(nil, "group", file)
+      action(:chgrp, "foo", "group", :verbose => false).should be_empty
+    end
+  end
+
   describe "#copy_file" do
     it "copies file from source to default destination" do
       action :copy_file, "task.thor"

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -41,7 +41,7 @@ describe Thor::Actions do
 
     it "logs status" do
       FileUtils.should_receive(:chmod_R).with(0755, file)
-      action(:chmod, "foo", 0755).should == "       chmod  foo\n"
+      action(:chmod, "foo", 0755).should == "       chmod  755 foo\n"
     end
 
     it "does not log status if required" do
@@ -62,9 +62,19 @@ describe Thor::Actions do
       action :chown, "foo", "user", "group"
     end
 
-    it "logs status" do
+    it "logs status with both user and group" do
       FileUtils.should_receive(:chown_R).with("user", "group", file)
-      action(:chown, "foo", "user", "group").should == "       chown  foo\n"
+      action(:chown, "foo", "user", "group").should == "       chown  user:group foo\n"
+    end
+
+    it "logs status with only user" do
+      FileUtils.should_receive(:chown_R).with("user", nil, file)
+      action(:chown, "foo", "user", nil).should == "       chown  user foo\n"
+    end
+
+    it "logs status with only group" do
+      FileUtils.should_receive(:chown_R).with(nil, "group", file)
+      action(:chown, "foo", nil, "group").should == "       chown  :group foo\n"
     end
 
     it "does not log status if required" do
@@ -87,7 +97,7 @@ describe Thor::Actions do
 
     it "logs status" do
       FileUtils.should_receive(:chown_R).with(nil, "group", file)
-      action(:chgrp, "foo", "group").should == "       chgrp  foo\n"
+      action(:chgrp, "foo", "group").should == "       chgrp  group foo\n"
     end
 
     it "does not log status if required" do


### PR DESCRIPTION
I've added two methods to Thor::Actions for modifying the ownership of a file or directory using FileUtils.chown_R (much like the existing chmod action).

The methods are Thor::Actions#chown for changing both user and group (or one of them if the other is passed as nil) and Thor::Actions#chgrp for only changing the group.
