### PR TITLE
README - Making an executable - nitpicky

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Example: mythorcommand.rb
     require "thor"
     class MyThorCommand < Thor
       desc "foo", "Prints foo"
-      def one
+      def foo
         puts "foo"
       end
     end


### PR DESCRIPTION
The "Making an executable" section does not work "out of the box." Just need to change "one" to "foo."
