### PR TITLE
Https url for  thor file location should not be expanded.

### DIFF
--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -73,7 +73,7 @@ class Thor::Runner < Thor #:nodoc:
       as = basename if as.empty?
     end
 
-    location = if options[:relative] || name =~ /^http:\/\//
+    location = if options[:relative] || name =~ /^https?:\/\//
       name
     else
       File.expand_path(name)


### PR DESCRIPTION
When installing a Thor file with https url, the url was expanded with the current directory.  This was blocking any further update.
