### PR TITLE
Warning for instance variable.

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -23,7 +23,7 @@ class Thor
       # Check if base is muted
       #
       def mute?
-        @mute
+        defined?(@mute) ? @mute : false
       end
 
       # Sets the output padding, not allowing less than zero values.


### PR DESCRIPTION
I noticed that while running the tests in rails3 there are warnings. instance variable @mute not initialized. Hope i didn't broke anything. 
Added defined? @mute to get rid of "instance variable @mute not initialized" when running rails3 railties tests.
