### PR TITLE
Workaround to allow Thor/Bundler to work under MacRuby

### DIFF
--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -65,10 +65,9 @@ class Thor
       @required_options ||= options.map{ |_, o| o.usage if o.required? }.compact.sort.join(" ")
     end
 
-    # Given a target, checks if this class name is not a private/protected method.
+    # Given a target, checks if this class name is a public method.
     def public_method?(instance) #:nodoc:
-      collection = instance.private_methods + instance.protected_methods
-      (collection & [name.to_s, name.to_sym]).empty?
+      !(instance.public_methods & [name.to_s, name.to_sym]).empty?
     end
 
     def sans_backtrace(backtrace, caller) #:nodoc:


### PR DESCRIPTION
This commit works around a bug in MacRuby which renders Thor (and in particular Bundler) unable to support tasks named 'open', or 'exec', for example.

  https://www.macruby.org/trac/ticket/204

While that bug needs to be fixed, this workaround was simple and a bit more direct than the existing implementation. I'm unaware of any security problems this commit would expose Thor to -- it should be equivalent to the original implementation.
