### PR TITLE
Patch to fix issue #128

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -198,9 +198,14 @@ class Thor
     def subcommands
       @subcommands ||= from_superclass(:subcommands, [])
     end
+    
+    def parent_commands
+      @parent_commands ||= from_superclass(:parent_commands, [])
+    end
 
     def subcommand(subcommand, subcommand_class)
       self.subcommands << subcommand.to_s
+      subcommand_class.parent_commands << subcommand.to_s
       subcommand_class.subcommand_help subcommand
       define_method(subcommand) { |*args| invoke subcommand_class, args }
     end

--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -39,6 +39,9 @@ class Thor
 
       formatted ||= ""
 
+      # Add parent commands (for subcommands)
+      klass.parent_commands.each {|parent_command| formatted << parent_command + ' ' }
+
       # Add usage with required arguments
       formatted << if klass && !klass.arguments.empty?
         usage.to_s.gsub(/^#{name}/) do |match|


### PR DESCRIPTION
As identified in issue #128, "Missing subcommand in help using register", the class help list for a subcommand does not list the subcommand name itself. This patch fixes that.
