### PR TITLE
Better patch for MacRuby bug

### DIFF
--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 class Thor
   class Task < Struct.new(:name, :description, :long_description, :usage, :options)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
@@ -67,7 +69,15 @@ class Thor
 
     # Given a target, checks if this class name is a public method.
     def public_method?(instance) #:nodoc:
-      !(instance.public_methods & [name.to_s, name.to_sym]).empty?
+      # The following seems strange, but it's a workaround for MacRuby bug 204
+      # Also, simply looking at whether task is in public_methods doesn't work for dynamic tasks
+      private_methods   = instance.private_methods
+      protected_methods = instance.protected_methods
+      public_methods    = instance.public_methods
+      public_and_private = public_methods & private_methods # Strangely, this isn't always [] in MacRuby!
+      private_or_protected = private_methods + protected_methods
+      !((public_and_private & [name.to_s, name.to_sym]).empty?) ||      # First, is it public AND private (MacRuby)?
+            (private_or_protected & [name.to_s, name.to_sym]).empty?    # Otherwise, is it not private or protected?
     end
 
     def sans_backtrace(backtrace, caller) #:nodoc:

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -55,13 +55,15 @@ describe Thor::Task do
   describe "#run" do
     it "runs a task by calling a method in the given instance" do
       mock = mock()
+      mock.should_receive(:public_methods).and_return([:can_has])
       mock.should_receive(:send).with("can_has", 1, 2, 3)
       task.run(mock, [1, 2, 3])
     end
 
     it "raises an error if the method to be invoked is private" do
       mock = mock()
-      mock.should_receive(:private_methods).and_return(['can_has'])
+      mock.should_receive(:private_methods).and_return([:can_has])
+      mock.should_receive(:public_methods).and_return([])
       mock.class.should_receive(:handle_no_task_error).with("can_has")
       task.run(mock)
     end


### PR DESCRIPTION
Better patch for MacRuby bug 204. Previous attempt (677b1e02b2e97940bb7dddf3de63cd753b2b10c2) introduces a bug for dynamic tasks. See issue 144

All my tests now pass. Can someone please verify that this still addresses the issue found by Christian Niles christian@nerdyc.com ?
