### PR TITLE
Fix rake desc not being passed to thor

### DIFF
--- a/lib/thor/rake_compat.rb
+++ b/lib/thor/rake_compat.rb
@@ -46,7 +46,8 @@ self.instance_eval do
       description << task.arg_names.map{ |n| n.to_s.upcase }.join(' ')
       description.strip!
 
-      klass.desc description, task.comment || non_namespaced_name
+      klass.desc description, Rake.application.last_description || non_namespaced_name
+      Rake.application.last_description = nil
       klass.send :define_method, non_namespaced_name do |*args|
         Rake::Task[task.name.to_sym].invoke(*args)
       end


### PR DESCRIPTION
This fixes this failing spec for rake 0.9.x:

```
$ bundle exec rspec spec/rake_compat_spec.rb
 ..F.....
Failures:

1) Thor::RakeCompat uses rake tasks descriptions on thor
 Failure/Error: ThorTask.tasks["cool"].description.should == "Say it's cool"
   expected: "Say it's cool"
        got: "cool" (using ==)
 # ./spec/rake_compat_spec.rb:44
```
