### PR TITLE
Two fixes for undefined tasks when no thorfiles are in project

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -426,8 +426,8 @@ class Thor
         end
       end
 
-      def handle_no_task_error(task) #:nodoc:
-        if $thor_runner
+      def handle_no_task_error(task, has_namespace = $thor_runner) #:nodoc:
+        if has_namespace
           raise UndefinedTaskError, "Could not find task #{task.inspect} in #{namespace.inspect} namespace."
         else
           raise UndefinedTaskError, "Could not find task #{task.inspect}."

--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -17,6 +17,7 @@ class Thor::Runner < Thor #:nodoc:
     if meth && !self.respond_to?(meth)
       initialize_thorfiles(meth)
       klass, task = Thor::Util.find_class_and_task_by_namespace(meth)
+      self.class.handle_no_task_error(task, false) if klass.nil?
       klass.start(["-h", task].compact, :shell => self.shell)
     else
       super
@@ -30,7 +31,7 @@ class Thor::Runner < Thor #:nodoc:
     meth = meth.to_s
     initialize_thorfiles(meth)
     klass, task = Thor::Util.find_class_and_task_by_namespace(meth)
-    raise UndefinedTaskError, "Could not find task #{task.inspect}" if klass.nil?
+    self.class.handle_no_task_error(task, false) if klass.nil?
     args.unshift(task) if task
     klass.start(args, :shell => self.shell)
   end


### PR DESCRIPTION
I came across these two bugs while in a rails project that had no thorfiles (i.e. no *.thor and Thorfile):

```
$ thor lst
/Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/runner.rb:34:in `method_missing': undefined method `start' for nil:NilClass (NoMethodError)
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/task.rb:108:in `run'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/bin/thor:6:in `<top (required)>'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/bin/thor:19:in `load'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/bin/thor:19:in `<main>'

$ thor help instal
/Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/runner.rb:20:in `help': undefined method `start' for nil:NilClass (NoMethodError)
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/gems/thor-0.14.6/bin/thor:6:in `<top (required)>'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/bin/thor:19:in `load'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@w/bin/thor:19:in `<main>'
```

I ended up handling the errors with Thor::Base.handle_no_task_error. Let me know if the fix needs adjusting
