### PR TITLE
allow color on mswin/mingw if ANSICON is installed

### DIFF
--- a/lib/thor/shell.rb
+++ b/lib/thor/shell.rb
@@ -8,7 +8,7 @@ class Thor
     def self.shell
       @shell ||= if ENV['THOR_SHELL'] && ENV['THOR_SHELL'].size > 0
         Thor::Shell.const_get(ENV['THOR_SHELL'])
-      elsif RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+      elsif ((RbConfig::CONFIG['host_os'] =~ /mswin|mingw/) && !(ENV['ANSICON']))
         Thor::Shell::Basic
       else
         Thor::Shell::Color


### PR DESCRIPTION
ANSICON provides ANSI escape sequences for Windows console programs.

https://github.com/adoxa/ansicon
