### PR TITLE
Let's ignore .rbx dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ test/version_tmp
 tmp
 tmtags
 tramp
+.rbx


### PR DESCRIPTION
It's the directory where rbx runtime stores its bytecode cache.
