### PR TITLE
s/enconding/encoding/ in Thorfile

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -1,4 +1,4 @@
-# enonding: utf-8
+# encoding: utf-8
 $:.unshift File.expand_path("../lib", __FILE__)
 
 require 'bundler'


### PR DESCRIPTION
At the top of Thorfile, it says "enconding" instead of "encoding". That's it, really.
