### PR TITLE
Hardlink spec fix

### DIFF
--- a/spec/actions/create_link_spec.rb
+++ b/spec/actions/create_link_spec.rb
@@ -42,7 +42,6 @@ describe Thor::Actions::CreateLink do
       destination_path = @hardlink_to
       File.exists?(destination_path).should be_true
       File.symlink?(destination_path).should be_false
-      ::FileUtils.rm_rf @hardlink_to
     end
 
     it "creates a symbolic link by default" do


### PR DESCRIPTION
This patch fixes "creates a hard link..." example in
spec/actions/create_link_spec.rb so that now it runs on any (sane old-school
;) box where /tmp is mounted from a different partition. Tested particularly
on FreeBSD 8.2
