### PR TITLE
allow recognizing symlinked ruby in ruby_command

### DIFF
--- a/lib/thor/util.rb
+++ b/lib/thor/util.rb
@@ -220,7 +220,7 @@ class Thor
         ruby = File.join(RbConfig::CONFIG['bindir'], ruby_name)
         ruby << RbConfig::CONFIG['EXEEXT']
 
-        # avoid using different name then ruby (on platforms supporting links)
+        # avoid using different name than ruby (on platforms supporting links)
         if ruby_name != 'ruby' && File.respond_to?(:readlink)
           begin
             alternate_ruby = File.join(RbConfig::CONFIG['bindir'], 'ruby')


### PR DESCRIPTION
fix to avoid https://github.com/wayneeseguin/rvm/issues/609

for rubies not being named `ruby` it will check if ruby exists and is a link to the original name

so in case of `jruby` and `rbx` it will still use `ruby`
