### PR TITLE
Added a .document file for rubydoc.info

### DIFF
--- a/.document
+++ b/.document
@@ -1,0 +1,5 @@
+lib/*.rb
+lib/**/*.rb
+-
+CHANGELOG.rdoc
+LICENSE.md


### PR DESCRIPTION
Added a `.document` file so the README, CHANGELOG and LICENSE will appear on [rubydoc.info](http://rubydoc.info/gems/thor).
