### PR TITLE
Add the possibility to hide an option

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -134,6 +134,7 @@ class Thor
     # :aliases  - Aliases for this option.
     # :type     - The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
     # :banner   - String to show on usage notes.
+    # :hide     - If you want to hide this option from the help.
     #
     def method_option(name, options={})
       scope = if options[:for]

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -238,6 +238,7 @@ class Thor
       # :aliases::  -- Aliases for this option. <b>Note:</b> Thor follows a convention of one-dash-one-letter options. Thus aliases like "-something" wouldn't be parsed; use either "\--something" or "-s" instead.
       # :type::     -- The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
       # :banner::   -- String to show on usage notes.
+      # :hide::     -- If you want to hide this option from the help.
       #
       def class_option(name, options={})
         build_option(name, options, class_options)
@@ -468,11 +469,13 @@ class Thor
           padding = options.collect{ |o| o.aliases.size }.max.to_i * 4
 
           options.each do |option|
-            item = [ option.usage(padding) ]
-            item.push(option.description ? "# #{option.description}" : "")
+            unless option.hide
+              item = [ option.usage(padding) ]
+              item.push(option.description ? "# #{option.description}" : "")
 
-            list << item
-            list << [ "", "# Default: #{option.default}" ] if option.show_default?
+              list << item
+              list << [ "", "# Default: #{option.default}" ] if option.show_default?
+            end
           end
 
           shell.say(group_name ? "#{group_name} options:" : "Options:")
@@ -494,7 +497,7 @@ class Thor
         def build_option(name, options, scope) #:nodoc:
           scope[name] = Thor::Option.new(name, options[:desc], options[:required],
                                                options[:type], options[:default], options[:banner],
-                                               options[:lazy_default], options[:group], options[:aliases])
+                                               options[:lazy_default], options[:group], options[:aliases], options[:hide])
         end
 
         # Receives a hash of options, parse them and add to the scope. This is a

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -1,14 +1,15 @@
 class Thor
   class Option < Argument #:nodoc:
-    attr_reader :aliases, :group, :lazy_default
+    attr_reader :aliases, :group, :lazy_default, :hide
 
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
-    def initialize(name, description=nil, required=nil, type=nil, default=nil, banner=nil, lazy_default=nil, group=nil, aliases=nil)
+    def initialize(name, description=nil, required=nil, type=nil, default=nil, banner=nil, lazy_default=nil, group=nil, aliases=nil, hide=nil)
       super(name, description, required, type, default, banner)
       @lazy_default = lazy_default
       @group        = group.to_s.capitalize if group
       @aliases      = [*aliases].compact
+      @hide         = hide
     end
 
     # This parse quick options given as method_options. It makes several


### PR DESCRIPTION
this is all the history: 

helios: Add the possibility to hide an option
add the hidden flag to option as well, to prevent display of this option when thor help task is called
## I want to add an option but I don't want the user know about it because it could not be save or because I want to use the option as a default parameter but not configurable from the end user.

eventualbuddha: Thanks for the patch! I'm not entirely sure why you'd want to do this. If the option isn't safe or you don't want the end user to be able to configure it, why expose it as an option at all? If you really want it to be externally configurable why not use an environment variable?

---

helios: Hi, I'm writing a dynamic wrapper and this wrapper can create thor tasks as well, a generic example of a regular wrapping is https://github.com/helios/bioruby-ngs/blob/master/lib/tasks/rna.thor#L10

The problem is , my wrapper has a program associated with it and options and arguments.
Some binary has a particular syntax like the one below (merge). Having an hidden option I can configure my wrapper setting an option which will be available as thor's option but not configurable by the end user.

but it works like regular unix binaries program_name options arguments

But other software has a syntax like this: 
where samtools is the main program then 
merge select a funcitionality and then
options and arguments
Usage: samtools merge [-nr] [-h inh.sam] [...]

Options: -n sort by read names
-r attach RG tag (inferred from file names)
-u uncompressed BAM output
-f overwrite the output BAM if exist
-1 compress level 1
-R STR merge file in the specified region STR [all]
-h FILE copy the header in FILE to [in1.bam]

that was my solution to the problem but If you have any idea please share it with me.

And thanks for your quick reply.
## Cheers.

wycats: We also had this case in Bundler for deprecated options.

@helios Can you rebase this patch?
@eventualbuddha does the use-case above plus the deprecation case satisfy you that this is a valid feature?

---

eventualbuddha:Deprecated options seems like a good enough reason to have something like this.
