### PR TITLE
Fixes issues with handling incorrect number of command arguments with JRuby

### DIFF
--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -87,7 +87,7 @@ class Thor
     end
 
     def sans_backtrace(backtrace, caller) #:nodoc:
-      saned  = backtrace.reject { |frame| frame =~ FILE_REGEXP }
+      saned  = backtrace.reject { |frame| frame =~ FILE_REGEXP || (frame =~ /\.java:/ && RUBY_PLATFORM =~ /java/) }
       saned -= caller
     end
 


### PR DESCRIPTION
It looks like Thor decides how command argument errors are handled based on exception backtraces.  After taking a closer look, JRuby backtraces include references to Java source code that disrupt `handle_argument_error?`.  In order to address this, I added an additional filter to the backtrace that rejects Java source files if `RUBY_PLATFORM` matches `/java/`.

This patch is meant to resolve #179 and makes the specs below pass with JRuby.  Any alternate solutions or feedback are welcome.

```
rspec ./spec/group_spec.rb:34 # Thor::Group#start raises an error when a Thor group task expects arguments
rspec ./spec/group_spec.rb:128 # Thor::Group#invoke_from_option with default type allows to invoke a class from the class binding by the given option
rspec ./spec/runner_spec.rb:107 # Thor::Runner#start does not swallow Thor::Group InvocationError
rspec ./spec/runner_spec.rb:112 # Thor::Runner#start does not swallow Thor InvocationError
rspec ./spec/thor_spec.rb:174 # Thor#start raises an error if a required param is not provided
rspec ./spec/thor_spec.rb:204 # Thor Thor#start when the user enters an unambiguous substring of a command should invoke a command, even when there's an alias the resolves to the same command
```
