### PR TITLE
Add password prompt through shell.ask("Pass: ", :password => true)

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -1,8 +1,10 @@
 require 'tempfile'
+require 'thor/shell/password'
 
 class Thor
   module Shell
     class Basic
+      include Password
       attr_accessor :base, :padding
 
       # Initialize base, mute and padding to nil.
@@ -46,8 +48,13 @@ class Thor
       #
       def ask(statement, *args)
         options = args.last.is_a?(Hash) ? args.pop : {}
-
-        options[:limited_to] ? ask_filtered(statement, options[:limited_to], *args) : ask_simply(statement, *args)
+        if options[:limited_to]
+          ask_filtered(statement, options[:limited_to], *args)
+        elsif options[:password]
+          ask_passwordly(statement, *args)
+        else
+          ask_simply(statement, *args)
+        end
       end
 
       # Say (print) something to the user. If the sentence ends with a whitespace

--- a/lib/thor/shell/password.rb
+++ b/lib/thor/shell/password.rb
@@ -1,0 +1,41 @@
+require 'tempfile'
+
+class Thor
+  module Shell
+    module Password
+      if RUBY_PLATFORM =~ /mswin32|mingw32/
+
+        def ask_passwordly(statement, color = nil)
+          say("#{statement} ", color)
+
+          require "Win32API"
+          char = nil
+          password = ''
+
+          while char = Win32API.new("crtdll", "_getch", [ ], "L").Call do
+            break if char == 10 || char == 13 # received carriage return or newline
+            if char == 127 || char == 8 # backspace and delete
+              password.slice!(-1, 1)
+            else
+              # windows might throw a -1 at us so make sure to handle RangeError
+              (password << char.chr) rescue RangeError
+            end
+          end
+          puts
+          return password
+        end
+
+      else
+
+        def ask_passwordly(statement, color = nil)
+          system "stty -echo"
+          password = ask(statement, color)
+          puts
+          return password
+        ensure
+          system "stty echo"
+        end
+      end
+    end
+  end
+end

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -22,6 +22,11 @@ describe Thor::Shell::Basic do
       shell.ask("Should I overwrite it?").should == "Sure"
     end
 
+    it "prints request a password and get the response" do
+      shell.should_receive(:ask_passwordly).with("Pass:").and_return('secret')
+      shell.ask("Pass:", :password => true).should == "secret"
+    end
+
     it "prints a message to the user with the available options and determines the correctness of the answer" do
       $stdout.should_receive(:print).with('What\'s your favorite Neopolitan flavor? ["strawberry", "chocolate", "vanilla"] ')
       $stdin.should_receive(:gets).and_return('chocolate')


### PR DESCRIPTION
Extracted carefully from the Heroku gem, this change adds cross-platform support for password requests. I am not sure about the best way to test this. Nor do I have a Windows box to test the Windows execution path.
