### PR TITLE
Add Thor#hide_if

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -66,6 +66,12 @@ class Thor
       end
     end
 
+    # Sets a block to evaluate if/when the next task will be hidden from the help command.
+    # Overrides the :hide option in desc
+    def hide_if(&block)
+      @hide= block
+    end
+
     # Maps an input to a task. If you define:
     #
     #   map "-T" => "list"
@@ -290,8 +296,12 @@ class Thor
 
       def create_task(meth) #:nodoc:
         if @usage && @desc
-          base_class = @hide ? Thor::HiddenTask : Thor::Task
+          base_class = Thor::Task
+
           tasks[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options)
+
+          tasks[meth].hidden = @hide
+
           @usage, @desc, @long_desc, @method_options, @hide = nil
           true
         elsif self.all_tasks[meth] || meth == "method_missing"

--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -11,8 +11,16 @@ class Thor
       self.options = other.options.dup if other.options
     end
 
+    def hidden=(proc_or_bool)
+      @hide = proc_or_bool
+    end
+
     def hidden?
-      false
+      begin
+        @hide.call
+      rescue NoMethodError
+        @hide
+      end
     end
 
     # By default, a task invokes a method in the thor class. You can change this
@@ -105,13 +113,6 @@ class Thor
     def handle_no_method_error?(instance, error, caller)
       not_debugging?(instance) &&
         error.message =~ /^undefined method `#{name}' for #{Regexp.escape(instance.to_s)}$/
-    end
-  end
-
-  # A task that is hidden in help messages but still invocable.
-  class HiddenTask < Task
-    def hidden?
-      true
     end
   end
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -35,6 +35,12 @@ class MyScript < Thor
     [type]
   end
 
+  desc "blockhidden", "hidden this is"
+  hide_if { $block_hide }
+  def blockhidden
+    true
+  end
+
   map "fu" => "zoo"
 
   desc "foo BAR", <<END

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -131,7 +131,7 @@ describe Thor do
         capture(:stdout) { MyScript.start(["help"]) }.should_not =~ /this is hidden/m
       end
 
-      it "but the task is still invokcable not show the task in help" do
+      it "can still invoke the task" do
         MyScript.start(["hidden", "yesyes"]).should == ["yesyes"]
       end
     end
@@ -155,6 +155,17 @@ describe Thor do
       arg, options = MyChildScript.start(args)
       arg.should == 'bird'
       options.should == { "force"=>true, "param"=>1.0, "other"=>"tweets" }
+    end
+  end
+
+  describe "#hide_if" do
+    it "does not show the task in help if the passed block evaluates to true" do
+      $block_hide = true
+      capture(:stdout) { MyScript.start(["help"]) }.should_not =~ /hidden this is/m
+    end
+    it "does show the task in help if the passed block evaluates to false" do
+      $block_hide = false
+      capture(:stdout) { MyScript.start(["help"]) }.should =~ /hidden this is/m
     end
   end
 


### PR DESCRIPTION
hide_if accepts a block, which it stores in the next-defined task, which will evaluate it whenever #hidden? is called, allowing tasks which hide and show themselves dynamically depending on arbitrary conditions.  For example, a cleanup script might only appear in the command list if there were any files that needed cleaning up.

Since Tasks can now have varied and dynamic values for #hidden, the class HiddenTask was removed as unnecessary.
