### PR TITLE
Do not assume 'rspec' found on $PATH is suitable

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -25,6 +25,6 @@ class Default < Thor
 
   desc "spec", "Run RSpec code examples"
   def spec
-    exec "rspec --color --format=documentation spec"
+    exec "#{Gem.ruby} -S rspec --color --format=documentation spec"
   end
 end


### PR DESCRIPTION
It could be arbitrarily old, or the Ruby run time that is running `thor :spec` may have a more suitable `rspec`.
