### PR TITLE
Add print_limits flag to not print limits for ask

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -47,7 +47,7 @@ class Thor
       def ask(statement, *args)
         options = args.last.is_a?(Hash) ? args.pop : {}
 
-        options[:limited_to] ? ask_filtered(statement, options[:limited_to], *args) : ask_simply(statement, *args)
+        options[:limited_to] ? ask_filtered(statement, options[:limited_to], options[:print_limits], *args) : ask_simply(statement, *args)
       end
 
       # Say (print) something to the user. If the sentence ends with a whitespace
@@ -312,11 +312,11 @@ HELP
           stdin.gets.strip
         end
 
-        def ask_filtered(statement, answer_set, *args)
+        def ask_filtered(statement, answer_set, print_limits, *args)
           correct_answer = nil
 
           until correct_answer
-            answer = ask_simply("#{statement} #{answer_set.inspect}", *args)
+            answer = ask_simply("#{statement} #{answer_set.inspect unless print_limits == false}", *args)
 
             correct_answer = answer_set.include?(answer) ? answer : nil
 

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -28,11 +28,24 @@ describe Thor::Shell::Basic do
       shell.ask("What's your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"]).should == "chocolate"
     end
 
+    it "prints a message to the user without the available options and determines the correctness of the answer" do
+      $stdout.should_receive(:print).with('What\'s your favorite Neopolitan flavor?  ')
+      $stdin.should_receive(:gets).and_return('chocolate')
+      shell.ask("What's your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"], :print_limits => false).should == "chocolate"
+    end
+
     it "prints a message to the user with the available options and reasks the question after an incorrect repsonse" do
       $stdout.should_receive(:print).with('What\'s your favorite Neopolitan flavor? ["strawberry", "chocolate", "vanilla"] ').twice
       $stdout.should_receive(:puts).with('Your response must be one of: ["strawberry", "chocolate", "vanilla"]. Please try again.')
       $stdin.should_receive(:gets).and_return('moose tracks', 'chocolate')
       shell.ask("What's your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"]).should == "chocolate"
+    end
+
+    it "prints a message to the user without the available options and reasks the question after an incorrect response" do
+      $stdout.should_receive(:print).with('What\'s your favorite Neopolitan flavor?  ').twice
+      $stdout.should_receive(:puts).with('Your response must be one of: ["strawberry", "chocolate", "vanilla"]. Please try again.')
+      $stdin.should_receive(:gets).and_return('moose tracks', 'chocolate')
+      shell.ask("What's your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"], :print_limits => false).should == "chocolate"
     end
   end
 


### PR DESCRIPTION
Printing the limits in the ask message may not always be desirable.

```
ask("Message: ", :limited_to => ["1","2"], :print_limits => false)
```

Simply prints 

```
Message:
```

instead of

```
Message: ["1", "2"]
```

but still validates that it is inside the limits. Specs are included
