### PR TITLE
A task can be recalled many times from the same task-caller

### DIFF
--- a/lib/thor/invocation.rb
+++ b/lib/thor/invocation.rb
@@ -117,8 +117,8 @@ class Thor
 
       unless current.include?(task.name)
         current << task.name
-        task.run(self, *args)
       end
+        task.run(self, *args)
     end
 
     # Invoke all tasks for the current instance.


### PR DESCRIPTION
``` ruby
class Caller < Thor
  desc "fake DATA", "fake caller"
  def fake(data)
     puts "#{data}"
  end

  desc "foo INFO", "foo main caller"
  def foo(info)
    invoke :fake, ["Pippo #{info}"]
    invoke :fake, ["Pluto #{info}"]
  end
end
```

Without patch:

```
thor caller:foo Duck
=> Pippo Duck
```

with patch:

```
=> Pippo Duck
=> Pluto Duck
```
