### PR TITLE
Escape path strings to avoid tripping up the regex

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -114,7 +114,7 @@ class Thor
     # the script started).
     #
     def relative_to_original_destination_root(path, remove_dot=true)
-      if path =~ /^#{@destination_stack[0]}/
+      if path =~ /^#{Regexp.escape(@destination_stack[0])}/
         path = path.gsub(@destination_stack[0], '.')
         path = remove_dot ? (path[2..-1] || '') : path
       end


### PR DESCRIPTION
This prevents tmp directories like "/var/folders/TT/TTeZp5JaF4y7rWPBqCM44U+++TI/-Tmp-/HcLtmr36-K3cA-F9vK-1FGl-hTrvaUr1BISG" from causing RegexpError exceptions like "nested *?+ in regexp: /^\/var\/folders\/TT\/TTeZp5JaF4y7rWPBqCM44U+++TI\/-Tmp-\/HcLtmr36-K3cA-F9vK-1FGl-hTrvaUr1BISG/"
