### PR TITLE
Add enum to string arguments

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -508,6 +508,7 @@ class Thor
 
               list << item
               list << [ "", "# Default: #{option.default}" ] if option.show_default?
+              list << [ "", "# Possible values: #{option.enum.join(', ')}" ] if option.enum
             end
           end
 

--- a/lib/thor/parser/argument.rb
+++ b/lib/thor/parser/argument.rb
@@ -2,7 +2,7 @@ class Thor
   class Argument #:nodoc:
     VALID_TYPES = [ :numeric, :hash, :array, :string ]
 
-    attr_reader :name, :description, :required, :type, :default, :banner
+    attr_reader :name, :description, :enum, :required, :type, :default, :banner
     alias :human_name :name
 
     def initialize(name, options={})
@@ -19,6 +19,7 @@ class Thor
       @type        = (type || :string).to_sym
       @default     = options[:default]
       @banner      = options[:banner] || default_banner
+      @enum        = options[:enum]
 
       validate! # Trigger specific validations
     end
@@ -43,7 +44,11 @@ class Thor
     protected
 
       def validate!
-        raise ArgumentError, "An argument cannot be required and have default value." if required? && !default.nil?
+        if required? && !default.nil?
+          raise ArgumentError, "An argument cannot be required and have default value."
+        elsif @enum && !@enum.is_a?(Array)
+          raise ArgumentError, "An argument cannot have an enum other than an array."
+        end
       end
 
       def valid_type?(type)

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -144,7 +144,13 @@ class Thor
         if no_or_skip?(name)
           nil
         else
-          shift
+          value = shift
+          if @switches.is_a?(Hash) && switch = @switches[name]
+            if switch.enum && !switch.enum.include?(value)
+              raise MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
+            end
+          end
+          value
         end
       end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -138,6 +138,11 @@ describe Thor::Base do
       content.should =~ /Foo options\:/
       content.should =~ /--last-name=LAST_NAME/
     end
+
+    it "displays choices for enums" do
+      content = capture(:stdout) { Enum.help(Thor::Base.shell.new) }
+      content.should =~ /Possible values\: apple, banana/
+    end
   end
 
   describe "#namespace" do

--- a/spec/fixtures/enum.thor
+++ b/spec/fixtures/enum.thor
@@ -1,0 +1,10 @@
+class Enum < Thor::Group
+  include Thor::Actions
+
+  desc "snack"
+  class_option "fruit", :aliases => "-f", :type => :string, :enum => %w(apple banana)
+  def snack
+    puts options['fruit']
+  end
+
+end

--- a/spec/parser/argument_spec.rb
+++ b/spec/parser/argument_spec.rb
@@ -25,6 +25,12 @@ describe Thor::Argument do
         argument(:task, :type => :string, :default => "bar", :required => true)
       }.should raise_error(ArgumentError, "An argument cannot be required and have default value.")
     end
+
+    it "raises an error if enum isn't an array" do
+      lambda {
+        argument(:task, :type => :string, :enum => "bar")
+      }.should raise_error(ArgumentError, "An argument cannot have an enum other than an array.")
+    end
   end
 
   describe "#usage" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ load File.join(File.dirname(__FILE__), "fixtures", "task.thor")
 load File.join(File.dirname(__FILE__), "fixtures", "group.thor")
 load File.join(File.dirname(__FILE__), "fixtures", "script.thor")
 load File.join(File.dirname(__FILE__), "fixtures", "invoke.thor")
+load File.join(File.dirname(__FILE__), "fixtures", "enum.thor")
 
 RSpec.configure do |config|
   config.before do


### PR DESCRIPTION
This gives users the ability to define a method option like this:

``` ruby
method_option "fruit", :type => :string, :enum => %w(apple banana)
```

which constrains the string value to the values in the array.
