### PR TITLE
Uncomment line does not properly uncomment lines

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -245,7 +245,7 @@ class Thor
     def uncomment_lines(path, flag, *args)
       flag = flag.respond_to?(:source) ? flag.source : flag
 
-      gsub_file(path, /^(\s*)#\s*(.*#{flag})/, '\1\2', *args)
+      gsub_file(path, /^(\s*)#[[:blank:]]*(.*#{flag})/, '\1\2', *args)
     end
 
     # Comment all lines matching a given regex.  It will leave the space

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -324,20 +324,20 @@ describe Thor::Actions do
       File.join(destination_root, "doc", "COMMENTER")
     end
 
-    unmodified_comments_file = /__start__\n # greenblue\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+    unmodified_comments_file = /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
 
     describe "#uncomment_lines" do
       it "uncomments all matching lines in the file" do
         action :uncomment_lines, "doc/COMMENTER", "green"
-        File.binread(file).should =~ /__start__\n greenblue\n# yellowblue\n#yellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n greenblue\n#\n# yellowblue\n#yellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
 
         action :uncomment_lines, "doc/COMMENTER", "red"
-        File.binread(file).should =~ /__start__\n greenblue\n# yellowblue\nyellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n greenblue\n#\n# yellowblue\nyellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
       end
 
       it "correctly uncomments lines with hashes in them" do
         action :uncomment_lines, "doc/COMMENTER", "ind#igo"
-        File.binread(file).should =~ /__start__\n # greenblue\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  ind#igo\n__end__/
       end
 
       it "does not modify already uncommented lines in the file" do
@@ -345,20 +345,25 @@ describe Thor::Actions do
         action :uncomment_lines, "doc/COMMENTER", "purple"
         File.binread(file).should =~ unmodified_comments_file
       end
+
+      it "does not uncomment the wrong line when uncommenting lines preceded by blank commented line" do
+        action :uncomment_lines, "doc/COMMENTER", "yellow"
+        File.binread(file).should =~ /__start__\n # greenblue\n#\nyellowblue\nyellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+      end
     end
 
     describe "#comment_lines" do
       it "comments lines which are not commented" do
         action :comment_lines, "doc/COMMENTER", "orange"
-        File.binread(file).should =~ /__start__\n # greenblue\n# yellowblue\n#yellowred\n #greenred\n# orange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
 
         action :comment_lines, "doc/COMMENTER", "purple"
-        File.binread(file).should =~ /__start__\n # greenblue\n# yellowblue\n#yellowred\n #greenred\n# orange\n    # purple\n  ind#igo\n  # ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    # purple\n  ind#igo\n  # ind#igo\n__end__/
       end
 
       it "correctly comments lines with hashes in them" do
         action :comment_lines, "doc/COMMENTER", "ind#igo"
-        File.binread(file).should =~ /__start__\n # greenblue\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  # ind#igo\n  # ind#igo\n__end__/
+        File.binread(file).should =~ /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  # ind#igo\n  # ind#igo\n__end__/
       end
 
       it "does not modify already commented lines" do

--- a/spec/fixtures/doc/COMMENTER
+++ b/spec/fixtures/doc/COMMENTER
@@ -1,5 +1,6 @@
 __start__
  # greenblue
+#
 # yellowblue
 #yellowred
  #greenred


### PR DESCRIPTION
If a blank commented line precedes a line to be uncommented,
then it does not get uncommented properly.

Given this standard excerpt from spec_helper.rb that rspec:install of rspec-rails generates:

``` ruby
RSpec.configure do |config|
  # ## Mock Framework
  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
  #
  # config.mock_with :mocha
  # config.mock_with :flexmock
  # config.mock_with :rr
end
```

using

``` ruby
uncomment_lines 'spec/spec_helper.rb', 'mock_with :mocha'
```

gives us this:

``` ruby
RSpec.configure do |config|
  # ## Mock Framework
  #
  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
  # config.mock_with :mocha
  # config.mock_with :flexmock
  # config.mock_with :rr
end
```

The problem is with the regex, \s matches newlines as well as spaces, so an empty comment line causes greediness to kick in and mess things up.

Fix and an extra spec for this attached.
