### PR TITLE
Only strip from stdin.gets if it wasn't ended with EOF

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -370,7 +370,7 @@ HELP
 
       def ask_simply(statement, color=nil)
         say("#{statement} ", color)
-        stdin.gets.strip
+        stdin.gets.tap{|text| text.strip! if text}
       end
 
       def ask_filtered(statement, answer_set, *args)

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -24,6 +24,13 @@ describe Thor::Shell::Basic do
       shell.ask("Should I overwrite it?").should == "Sure"
     end
 
+    it "prints a message and returns nil if EOF is sent to stdin" do
+      $stdout.should_receive(:print).with(" ")
+      $stdin.should_receive(:gets).and_return(nil)
+      shell.ask("").should == nil
+    end
+
+
     it "prints a message to the user with the available options and determines the correctness of the answer" do
       $stdout.should_receive(:print).with('What\'s your favorite Neopolitan flavor? ["strawberry", "chocolate", "vanilla"] ')
       $stdin.should_receive(:gets).and_return('chocolate')


### PR DESCRIPTION
When stdin.gets is ended by pressing ctrl-d or the equivalent EOF keys
it returns nil and ask_simply raises a NoMethodException when calling
strip.
