### PR TITLE
translate value for 'has_key?' to Hash

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -45,6 +45,10 @@ class Thor
         self
       end
 
+      def has_key?(key)
+        super(convert_key(key))
+      end
+
       protected
 
         def convert_key(key)


### PR DESCRIPTION
this will translate the value of the 'has_key?' message to the parent of HashWithIndifferentAccess (Hash)
