### PR TITLE
Fixed newline handling bug in Thor::Shell::Basic#say

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -58,7 +58,7 @@ class Thor
       # ==== Example
       # say("I know you knew that.")
       #
-      def say(message="", color=nil, force_new_line=(message.to_s !~ /( |\t)$/))
+      def say(message="", color=nil, force_new_line=(message.to_s !~ /( |\t)\Z/))
         message = message.to_s
 
         message = set_color(message, *color) if color

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -80,6 +80,11 @@ describe Thor::Shell::Basic do
       shell.say("Running... ")
     end
 
+    it "does not use a new line with whitespace+newline embedded" do
+      $stdout.should_receive(:puts).with("It's \nRunning...")
+      shell.say("It's \nRunning...")
+    end
+
     it "prints a message to the user without new line" do
       $stdout.should_receive(:print).with("Running...")
       shell.say("Running...", nil, false)


### PR DESCRIPTION
Thor::Shell::Basic#say method would suppress newline when message contained whitespace directly followed by a newline embedded within the string (not at the end). Fixed by modifying the offending regex, causing it to match at end of string instead of end of line. Also added related test.
