### PR TITLE
Allow passing options as arguments after '--'.

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -5,6 +5,7 @@ class Thor
     EQ_RE       = /^(--\w+(?:-\w+)*|-[a-z])=(.*)$/i
     SHORT_SQ_RE = /^-([a-z]{2,})$/i # Allow either -x -v or -xv style for single char args
     SHORT_NUM   = /^(-[a-z])#{NUMERIC}$/i
+    OPTS_END    = '--'.freeze
 
     # Receives a hash and makes it switches.
     def self.to_switches(options)
@@ -50,39 +51,51 @@ class Thor
       @extra
     end
 
+    def peek
+      return super unless @parsing_options
+
+      result = super
+      if result == OPTS_END
+        shift
+        @parsing_options = false
+        super
+      else
+        result
+      end
+    end
+
     def parse(args)
       @pile = args.dup
+      @parsing_options = true
 
       while peek
-        match, is_switch = current_is_switch?
-        shifted = shift
+        if parsing_options?
+          match, is_switch = current_is_switch?
+          shifted = shift
 
-        if shifted == '--'
-          @extra += @pile
-          @pile.clear
-          break
-        end
+          if is_switch
+            case shifted
+              when SHORT_SQ_RE
+                unshift($1.split('').map { |f| "-#{f}" })
+                next
+              when EQ_RE, SHORT_NUM
+                unshift($2)
+                switch = $1
+              when LONG_RE, SHORT_RE
+                switch = $1
+            end
 
-        if is_switch
-          case shifted
-            when SHORT_SQ_RE
-              unshift($1.split('').map { |f| "-#{f}" })
-              next
-            when EQ_RE, SHORT_NUM
-              unshift($2)
-              switch = $1
-            when LONG_RE, SHORT_RE
-              switch = $1
+            switch = normalize_switch(switch)
+            option = switch_option(switch)
+            @assigns[option.human_name] = parse_peek(switch, option)
+          elsif match
+            @extra << shifted
+            @extra << shift while peek && peek !~ /^-/
+          else
+            @extra << shifted
           end
-
-          switch = normalize_switch(switch)
-          option = switch_option(switch)
-          @assigns[option.human_name] = parse_peek(switch, option)
-        elsif match
-          @extra << shifted
-          @extra << shift while peek && peek !~ /^-/
         else
-          @extra << shifted
+          @extra << shift
         end
       end
 
@@ -123,6 +136,10 @@ class Thor
         end
       end
 
+      def current_is_value?
+        peek && (!parsing_options? || super)
+      end
+
       def switch?(arg)
         switch_option(normalize_switch(arg))
       end
@@ -139,6 +156,11 @@ class Thor
       #
       def normalize_switch(arg)
         (@shorts[arg] || arg).tr('_', '-')
+      end
+
+      def parsing_options?
+        peek
+        @parsing_options
       end
 
       # Parse boolean values which can be given as --foo=true, --foo or --no-foo.
@@ -162,7 +184,7 @@ class Thor
       # Parse the value at the peek analyzing if it requires an input or not.
       #
       def parse_peek(switch, option)
-        if current_is_switch_formatted? || last?
+        if parsing_options? && (current_is_switch_formatted? || last?)
           if option.boolean?
             # No problem for boolean types
           elsif no_or_skip?(switch)

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -143,6 +143,30 @@ describe Thor::Options do
       remaining.should == %w[moo --foo def -a]
     end
 
+    it "ignores -- when looking for single option values" do
+      create(:foo => :string, :bar => :required)
+      parse(%w[--bar -- --foo def -a]).should == {"bar" => "--foo"}
+      remaining.should == %w[def -a]
+    end
+
+    it "ignores -- when looking for array option values" do
+      create(:foo => :array)
+      parse(%w[--foo a b -- c d -e]).should == {"foo" => %w[a b c d -e]}
+      remaining.should == []
+    end
+
+    it "ignores -- when looking for hash option values" do
+      create(:foo => :hash)
+      parse(%w[--foo a:b -- c:d -e]).should == {"foo" => {'a' => 'b', 'c' => 'd'}}
+      remaining.should == %w[-e]
+    end
+
+    it "ignores trailing --" do
+      create(:foo => :string)
+      parse(%w[--foo --]).should == {"foo" => nil}
+      remaining.should == []
+    end
+
     describe "with no input" do
       it "and no switches returns an empty hash" do
         create({})


### PR DESCRIPTION
This should allow the use case brought up by wycats/thor#259, namely that this command does not work:

`foreman run ruby -Itest test/unit/a_test.rb`

With this patch you could run it like so:

`foreman run -- ruby -Itest test/unit/a_test.rb`
