### PR TITLE
HWIA#to_hash should convert to normal Hash objects

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -45,6 +45,11 @@ class Thor
         self
       end
 
+      # Convert to a Hash with String keys.
+      def to_hash
+        Hash.new(default).merge!(self)
+      end
+
       protected
 
         def convert_key(key)

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -40,4 +40,9 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(other[:force]).to eq(false)
     expect(other[:baz]).to eq("boom")
   end
+
+  it "converts to a traditional hash" do
+    expect(@hash.to_hash.class).to eq(Hash)
+    expect(@hash).to eq({ 'foo' => 'bar', 'baz' => 'bee', 'force' => true })
+  end
 end


### PR DESCRIPTION
ActiveSupport::HashWithIndifferentAccess defines a `to_hash` method that converts to a vanilla `Hash` object, using `String` objects for the keys. Thor's version does not do this, and instead maintains it as the HWIA object instead.

This pull request fixes that problem, causing Thor's HWIA to now return a standard Ruby Hash object, just like AS does.
