### PR TITLE
Autoload Thor::Group

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -10,6 +10,7 @@ require 'thor/util'
 class Thor
   autoload :Actions,    'thor/actions'
   autoload :RakeCompat, 'thor/rake_compat'
+  autoload :Group,      'thor/group'
 
   # Shortcuts for help.
   HELP_MAPPINGS       = %w(-h -? --help -D)


### PR DESCRIPTION
Added `autoload :Group` to base.rb because thor.rb needs Thor::Group.

https://github.com/wycats/thor/blob/master/lib/thor.rb#L29
