### PR TITLE
Slightly more sensible error when no args required

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -471,8 +471,12 @@ class Thor
         msg = "#{basename} #{task.name}"
         if arity
           required = arity < 0 ? (-1 - arity) : arity
-          msg << " requires at least #{required} argument"
-          msg << "s" if required > 1
+          if required == 0
+            msg << " should have no arguments"
+          else
+            msg << " requires at least #{required} argument"
+            msg << "s" if required > 1
+          end
         else
           msg = "call #{msg} as"
         end


### PR DESCRIPTION
Replaces errors such as:
`<command> requires at least 0 argument: "<command>"`
with:
`<command> should have no arguments: "<command>"`
