### PR TITLE
Updated rake_compat comments to reflect Rspec 2.0 changes

### DIFF
--- a/lib/thor/rake_compat.rb
+++ b/lib/thor/rake_compat.rb
@@ -12,7 +12,7 @@ class Thor
   #     include Thor::RakeCompat
   #
   #     RSpec::Core::RakeTask.new(:spec) do |t|
-  #       t.spec_opts = ['--options', "spec/spec.opts"]
+  #       t.spec_opts = ['--options', "./.rspec"]
   #       t.spec_files = FileList['spec/**/*_spec.rb']
   #     end
   #   end


### PR DESCRIPTION
I believe that Rspec 2.0 wants:

``` ruby
RSpec::Core::RakeTask.new(:spec) do |t|
  t.spec_opts = ['--options', "./.rspec"]
  t.spec_files = FileList['spec/**/*_spec.rb']
end
```

In addition to:

``` ruby
require 'thor/rake_compat'
require 'rspec/core/rake_task'
```

Please let me know if anything is missing from this pull request. Cheers!
