### PR TITLE
Add Ruby 2.0.0 to travis matrix again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  #- ruby-head
+  - 2.0.0
 script: bundle exec thor spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rspec-mocks', :github => 'rspec/rspec-mocks', :branch => 'master'
+
 platforms :mri_18 do
   gem 'ruby-debug', '>= 0.10.3'
 end


### PR DESCRIPTION
We need to use rspec-mocks master since there is a bug with stubs in FileUtils
module.

See https://github.com/rspec/rspec-mocks/issues/210
