### PR TITLE
Delete symlink of non-existent source in revoking

### DIFF
--- a/lib/thor/actions/create_link.rb
+++ b/lib/thor/actions/create_link.rb
@@ -52,6 +52,9 @@ class Thor
         given_destination
       end
 
+      def exists?
+        super || File.symlink?(destination)
+      end
     end
   end
 end

--- a/spec/actions/create_link_spec.rb
+++ b/spec/actions/create_link_spec.rb
@@ -23,6 +23,10 @@ describe Thor::Actions::CreateLink do
     capture(:stdout) { @action.invoke! }
   end
 
+  def revoke!
+    capture(:stdout) { @action.revoke! }
+  end
+
   def silence!
     @silence = true
   end
@@ -76,6 +80,16 @@ describe Thor::Actions::CreateLink do
       expect(@action.identical?).to be_false
       invoke!
       expect(@action.identical?).to be_true
+    end
+  end
+
+  describe "#revoke!" do
+    it "removes the symbolic link of non-existent destination" do
+      create_link("doc/config.rb")
+      invoke!
+      File.delete(@tempfile.path)
+      revoke!
+      expect(File.symlink?(@action.destination)).to be_false
     end
   end
 end


### PR DESCRIPTION
In a phase of revoking CreateLink, it confirms the existence of source file only by `File.exists?`. So when the destination is a symlink and the source file does not exist, it returns false. This can be trouble depending on the execution sequence.
