### PR TITLE
Fix on wrong message when zero arguments needed

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -469,7 +469,7 @@ class Thor
 
       def handle_argument_error(task, error, arity=nil) #:nodoc:
         msg = "#{basename} #{task.name}"
-        if arity
+        if arity && arity != 0
           required = arity < 0 ? (-1 - arity) : arity
           if required == 0
             msg << " should have no arguments"


### PR DESCRIPTION
Currently, Thor prints `bundle init requires at least 0 argument: "bundle init".`
I believe to avoid confusion, it should print the same message as in case of nil "arity" value: `call bundle init as: "bundle init".`
