### PR TITLE
only display colors if output medium supports colors

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -61,7 +61,7 @@ class Thor
       def say(message="", color=nil, force_new_line=(message.to_s !~ /( |\t)\Z/))
         message = message.to_s
 
-        message = set_color(message, *color) if color
+        message = set_color(message, *color) if color && can_display_colors?
 
         spaces = "  " * padding
 
@@ -274,6 +274,10 @@ class Thor
       end
 
     protected
+
+      def can_display_colors?
+        false
+      end
 
       def lookup_color(color)
         return color unless color.is_a?(Symbol)

--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -94,6 +94,10 @@ class Thor
 
       protected
 
+        def can_display_colors?
+          stdout.tty?
+        end
+
         # Overwrite show_diff to show diff with colors if Diff::LCS is
         # available.
         #

--- a/lib/thor/shell/html.rb
+++ b/lib/thor/shell/html.rb
@@ -73,6 +73,10 @@ class Thor
 
       protected
 
+        def can_display_colors?
+          true
+        end
+
         # Overwrite show_diff to show diff with colors if Diff::LCS is
         # available.
         #

--- a/spec/shell/color_spec.rb
+++ b/spec/shell/color_spec.rb
@@ -5,13 +5,26 @@ describe Thor::Shell::Color do
     @shell ||= Thor::Shell::Color.new
   end
 
+  before do
+    StringIO.any_instance.stub(:tty?).and_return(true)
+  end
+
   describe "#say" do
-    it "set the color if specified" do
+    it "set the color if specified and tty?" do
       out = capture(:stdout) do
         shell.say "Wow! Now we have colors!", :green
       end
 
       expect(out.chomp).to eq("\e[32mWow! Now we have colors!\e[0m")
+    end
+
+    it "does not set the color if output is not a tty" do
+      out = capture(:stdout) do
+        $stdout.should_receive(:tty?).and_return(false)
+        shell.say "Wow! Now we have colors!", :green
+      end
+
+      expect(out.chomp).to eq("Wow! Now we have colors!")
     end
 
     it "does not use a new line even with colors" do
@@ -68,6 +81,7 @@ describe Thor::Shell::Color do
     describe "when a block is given" do
       it "invokes the diff command" do
         $stdout.stub!(:print)
+        $stdout.stub!(:tty?).and_return(true)
         $stdin.should_receive(:gets).and_return('d')
         $stdin.should_receive(:gets).and_return('n')
 


### PR DESCRIPTION
- make piping possible/easier (no color-code replacement necessary)
- make commandline output from non-tty not have distracting escape sequences
