### PR TITLE
fix warnings from 'hidden' test (issue #265)

### DIFF
--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -267,8 +267,8 @@ describe Thor do
         expect(MyScript.start(["z"])).to eq(MyScript.start(["zoo"]))
       end
 
-      it "invokes a command, even when there's an alias the resolves to the same command" do
-        expect(MyScript.start(["hi"])).to eq(MyScript.start(["hidden"]))
+      it "invokes a command, even when there's an alias it resolves to the same command" do
+        expect(MyScript.start(["hi", "arg"])).to eq(MyScript.start(["hidden", "arg"]))
       end
 
       it "invokes an alias" do


### PR DESCRIPTION
The warning from the 'hidden' test was caused by invoking the `hidden` command with no arguments when it was defined as requiring one argument.  Calling with the correct number of arguments silences the warning.
