### PR TITLE
Updated coveralls gem to 0.5.7 to fix Travis crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 group :test do
   gem 'childlabor'
-  gem 'coveralls', :require => false
+  gem 'coveralls', '>=0.5.7', :require => false
   gem 'fakeweb', '>= 1.3'
   gem 'rspec', '>= 2.11'
   gem 'rspec-mocks', '>= 2.12.2'


### PR DESCRIPTION
Hi all, the pertinent update to the coveralls-ruby gem was adding a ":utf-8" here:

``` ruby
File.open(file.filename, "rb:utf-8").read
```

Before it was crashing during the Travis build with this error:

```
Encoding::UndefinedConversionError
956"\xC3" from ASCII-8BIT to UTF-8
```

As seen on this job:
https://travis-ci.org/wycats/thor/jobs/5078933

Thanks!
