### PR TITLE
Spec outputting to stderr

### DIFF
--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -126,8 +126,14 @@ describe Thor::Group do
       end
 
       it "allows to invoke a class from the class binding by the given option" do
-        content = capture(:stdout) { G.start(["--invoked", "e"]) }
+        error = nil
+        content = capture(:stdout) {
+          error = capture(:stderr) {
+            G.start(["--invoked", "e"])
+          }
+        }
         expect(content).to match(/invoke  e/)
+        expect(error).to match(/ERROR: thor two was called with arguments/)
       end
 
       it "shows invocation information to the user" do


### PR DESCRIPTION
The test on line 128 in group_spec is outputting to stderr. I added a capture for it, but this is probably not the expected behavior. Probably introduced in c1665b3. /cc @JoshCheek
