### PR TITLE
Update to latest rspec and stop requiring mocks separately.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,7 @@ group :test do
   gem 'childlabor'
   gem 'coveralls', '>=0.5.7', :require => false
   gem 'fakeweb', '>= 1.3'
-  gem 'rspec', '>= 2.11'
-  gem 'rspec-mocks', '>= 2.12.2'
+  gem 'rspec', '>= 2.13'
   gem 'simplecov', :require => false
 end
 


### PR DESCRIPTION
@wycats @sferik 

I tried to `bundle install` and got this:

```
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/..
You have requested:
  rspec-mocks >= 2.12.2
The bundle currently has rspec-mocks locked at 2.11.3.Try running `bundle update rspec-mocks`
```

This seems to have fixed it.
