### PR TITLE
Shell#ask: support a noecho option for stdin

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -41,10 +41,15 @@ class Thor
       # they will be shown a message stating that one of those answers
       # must be given and re-asked the question.
       #
+      # If asking for sensitive information, the :echo option can be set
+      # to false to mask user input from $stdin.
+      #
       # ==== Example
       # ask("What is your name?")
       #
       # ask("What is your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"])
+      #
+      # ask("What is your password?", :echo => false)
       #
       def ask(statement, *args)
         options = args.last.is_a?(Hash) ? args.pop : {}
@@ -383,7 +388,7 @@ HELP
         message = [statement, ("(#{default})" if default), nil].uniq.join(" ")
         say(message, color)
 
-        result = if options[:noecho]
+        result = if options[:echo] == false
           stdin.noecho(&:gets)
         else
           stdin.gets

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -20,6 +20,7 @@ describe Thor::Shell::Basic do
     it "prints a message to the user and gets the response" do
       $stdout.should_receive(:print).with("Should I overwrite it? ")
       $stdin.should_receive(:gets).and_return('Sure')
+      $stdin.should_not_receive(:noecho).and_return('Sure')
       expect(shell.ask("Should I overwrite it?")).to eq("Sure")
     end
 
@@ -29,10 +30,10 @@ describe Thor::Shell::Basic do
       expect(shell.ask("")).to eq(nil)
     end
 
-    it "prints a message to the user and does not echo stdin if the noecho option is set to true" do
+    it "prints a message to the user and does not echo stdin if the echo option is set to false" do
       $stdout.should_receive(:print).with('What\'s your password? ')
       $stdin.should_receive(:noecho).and_return('mysecretpass')
-      expect(shell.ask("What's your password?", :noecho => true)).to eq("mysecretpass")
+      expect(shell.ask("What's your password?", :echo => false)).to eq("mysecretpass")
     end
 
     it "prints a message to the user with the available options and determines the correctness of the answer" do


### PR DESCRIPTION
Support using "ask" without echoing back stdin for passwords and other sensitive information.

Relies on io/console and http://apidock.com/ruby/IO/noecho (not supported in 1.8.7 or 1.9.2 unfortunately)
