### PR TITLE
Add :raise_error option to run action

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -227,7 +227,8 @@ class Thor
     # ==== Parameters
     # command<String>:: the command to be executed.
     # config<Hash>:: give :verbose => false to not log the status, :capture => true to hide to output. Specify :with
-    #                to append an executable to command execution.
+    #                to append an executable to command execution, :raise_error => true to raise CommandFailedError if
+    #                the command exits with a non-zero status code.
     #
     # ==== Example
     #
@@ -249,8 +250,14 @@ class Thor
       say_status :run, desc, config.fetch(:verbose, true)
 
       unless options[:pretend]
-        config[:capture] ? `#{command}` : system("#{command}")
+        result = config[:capture] ? `#{command}` : system("#{command}")
+        if config.fetch(:raise_error, false) && 0 != $?.exitstatus
+          error =  $?.exitstatus.nil? ? "no exit status (likely force killed)" : "exit status #{$?.exitstatus}"
+          raise CommandFailedError.new("#{command} failed with #{error}")
+        end
+        result
       end
+
     end
 
     # Executes a ruby script (taking into account WIN32 platform quirks).

--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -13,6 +13,10 @@ class Thor
   end
   UndefinedTaskError = UndefinedCommandError
 
+  # Optionally raised when a run action fails
+  class CommandFailedError < Error
+  end
+
   # Raised when a command was found, but not invoked properly.
   class InvocationError < Error
   end


### PR DESCRIPTION
Passing :raise_error => true to a run action will raise a
`CommandFailedError` if the command has a non-zero exit status.

This is useful for replicating bash's `set -e` functionality, common in
shell scripting.

```
run("ls no_such_file", :raise_error => true) # raises CommandFailedError
```
