### PR TITLE
Fixes syntax error in option_spec

### DIFF
--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -176,7 +176,7 @@ describe Thor::Option do
     end
 
     it "uses padding when no aliases are given" do
-      expect(parse(:foo, :boolean).usage)).to eq("    [--foo]")
+      expect(parse(:foo, :boolean).usage).to eq("    [--foo]")
     end
 
     it "uses banner when supplied" do


### PR DESCRIPTION
Removes extra closing parenthesis, revealing a legitimate test failure

```
Failures:

  1) Thor::Option#usage uses padding when no aliases are given
     Failure/Error: expect(parse(:foo, :boolean).usage).to eq("    [--foo]")

       expected: "    [--foo]"
            got: "[--foo]"

       (compared using ==)
```
