### PR TITLE
Assert #usage uses 0 padding when no aliases given

### DIFF
--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -175,8 +175,8 @@ describe Thor::Option do
       expect(parse(:foo, :boolean).usage).to eq("[--foo]")
     end
 
-    it "uses padding when no aliases are given" do
-      expect(parse(:foo, :boolean).usage).to eq("    [--foo]")
+    it "does not use padding when no aliases are given" do
+      expect(parse(:foo, :boolean).usage).to eq("[--foo]")
     end
 
     it "uses banner when supplied" do


### PR DESCRIPTION
- The code reads as if no aliases => no padding
  - https://github.com/erikhuda/thor/blob/master/lib/thor/base.rb#L511-L518
