### PR TITLE
Fix broken link on Thor website

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,7 @@
   <body>
     <div id="main">
       <header>
-Thor is a toolkit for building powerful command-line interfaces. It is
-used in Bundler, Vagrant, Rails, and
-<a href="http://gemfamily.info/gems/thor">197 other gems</a>.
+Thor is a toolkit for building powerful command-line interfaces. It is used in Bundler, Vagrant, Rails and others.
 </header>
 
 <h1 id="getting-started">Getting Started</h1>


### PR DESCRIPTION
# Summary

There was a broken link in the description on the thor website. 
This PR removes the dead link. :+1: 
# Changes
- [x] Fixed broken link
- [x] Change `197 other gems` to `and others`
