### PR TITLE
Simple Override Of DynamicCommand

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -350,7 +350,7 @@ class Thor
         end
       else
         args, opts = given_args, nil
-        command = Thor::DynamicCommand.new(meth)
+        command = dynamic_command_class.new(meth)
       end
 
       opts = given_opts || opts || []
@@ -374,6 +374,10 @@ class Thor
 
     def baseclass #:nodoc:
       Thor
+    end
+
+    def dynamic_command_class #:nodoc:
+      Thor::DynamicCommand
     end
 
     def create_command(meth) #:nodoc:


### PR DESCRIPTION
This helps me to override DynamicCommand without having to do `Thor::DynamicCommand.class_eval`.

What I do now is

``` ruby
class MyThorApp < Thor::App
  def self.dynamic_command_class
    DynamicCommand
  end

  class DynamicCommand < Thor::DynamicCommand
    def run(*args)
      # do my stuff here
    end
  end
end
```

I didn't add a test, yet, since I didn't know if this is the intended way of handling dynamic commands in Thor. Let me know when I'm wrong here :-)
