### PR TITLE
Fixes #285 - Process a command's options when it is executed with invoke

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -46,9 +46,9 @@ class Thor
       # new, passing in the two halves of the arguments Array as the
       # first two parameters.
 
+      command_options = config.delete(:command_options) # hook for start
+      parse_options = parse_options.merge(command_options) if command_options
       if options.is_a?(Array)
-        command_options = config.delete(:command_options) # hook for start
-        parse_options = parse_options.merge(command_options) if command_options
         array_options, hash_options = options, {}
       else
         # Handle the case where the class was explicitly instantiated

--- a/spec/fixtures/invoke.thor
+++ b/spec/fixtures/invoke.thor
@@ -53,6 +53,12 @@ class B < Thor
   def three
     self
   end
+
+  desc "four", "invoke four"
+  option :defaulted_value, :type => :string, :default => 'default'
+  def four
+    options.defaulted_value
+  end
 end
 
 class C < Thor::Group

--- a/spec/invocation_spec.rb
+++ b/spec/invocation_spec.rb
@@ -50,6 +50,14 @@ describe Thor::Invocation do
       expect(A.new([], :foo => :bar).invoke("b:two")).to eq({ "foo" => :bar })
     end
 
+    it "uses default options from invoked class if no matching arguments are given" do
+      expect(A.new([]).invoke("b:four")).to eq("default")
+    end
+
+    it "overrides default options if options are passed to the invoker" do
+      expect(A.new([], { :defaulted_value => "not default"}).invoke("b:four")).to eq("not default")
+    end
+
     it "dump configuration values to be used in the invoked class" do
       base = A.new
       expect(base.invoke("b:three").shell).to eq(base.shell)


### PR DESCRIPTION
I ran into the same issue as #285 and, after some digging around, I found the following.  In the case that the options were pre-parsed and coming in as a hash (as they do on invoke), the command's options were not being merged into the options to be parsed.  After reviewing some of the surrounding code, it seemed appropriate to move the command options merge outside of the single if branch as well.  I'm not extremely familiar with the code, so, hopefully, I did not miss some reason that this was not proper.  All of the existing tests continued to pass after this small change and the new test I wrote to expose the issue also passed afterwards.
