### PR TITLE
Make say and say_status thread safe.

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -71,16 +71,13 @@ class Thor
       #
       def say(message="", color=nil, force_new_line=(message.to_s !~ /( |\t)\Z/))
         message = message.to_s
-
         message = set_color(message, *color) if color && can_display_colors?
 
-        spaces = "  " * padding
+        buffer = "  " * padding
+        buffer << message
+        buffer << "\n" if force_new_line && !message.end_with?("\n")
 
-        if force_new_line
-          stdout.puts(spaces + message)
-        else
-          stdout.print(spaces + message)
-        end
+        stdout.print(buffer)
         stdout.flush
       end
 
@@ -97,7 +94,10 @@ class Thor
         status = status.to_s.rjust(12)
         status = set_color status, color, true if color
 
-        stdout.puts "#{status}#{spaces}#{message}"
+        buffer = "#{status}#{spaces}#{message}"
+        buffer << "\n" unless buffer.end_with?("\n")
+
+        stdout.print(buffer)
         stdout.flush
       end
 

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -44,7 +44,7 @@ describe Thor::Shell::Basic do
 
     it "prints a message to the user with the available options and reasks the question after an incorrect repsonse" do
       expect($stdout).to receive(:print).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ').twice
-      expect($stdout).to receive(:puts).with('Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.')
+      expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
       expect($stdin).to receive(:gets).and_return('moose tracks', 'chocolate')
       expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"])).to eq("chocolate")
     end
@@ -57,7 +57,7 @@ describe Thor::Shell::Basic do
 
     it "prints a message to the user with the available options and reasks the question after an incorrect repsonse and then returns the default" do
       expect($stdout).to receive(:print).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] (vanilla) ').twice
-      expect($stdout).to receive(:puts).with('Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.')
+      expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
       expect($stdin).to receive(:gets).and_return('moose tracks', '')
       expect(shell.ask("What's your favorite Neopolitan flavor?", :default => "vanilla", :limited_to => ["strawberry", "chocolate", "vanilla"])).to eq("vanilla")
     end
@@ -89,7 +89,7 @@ describe Thor::Shell::Basic do
 
   describe "#say" do
     it "prints a message to the user" do
-      expect($stdout).to receive(:puts).with("Running...")
+      expect($stdout).to receive(:print).with("Running...\n")
       shell.say("Running...")
     end
 
@@ -99,7 +99,7 @@ describe Thor::Shell::Basic do
     end
 
     it "does not use a new line with whitespace+newline embedded" do
-      expect($stdout).to receive(:puts).with("It's \nRunning...")
+      expect($stdout).to receive(:print).with("It's \nRunning...\n")
       shell.say("It's \nRunning...")
     end
 
@@ -111,18 +111,18 @@ describe Thor::Shell::Basic do
 
   describe "#say_status" do
     it "prints a message to the user with status" do
-      expect($stdout).to receive(:puts).with("      create  ~/.thor/command.thor")
+      expect($stdout).to receive(:print).with("      create  ~/.thor/command.thor\n")
       shell.say_status(:create, "~/.thor/command.thor")
     end
 
     it "always uses new line" do
-      expect($stdout).to receive(:puts).with("      create  ")
+      expect($stdout).to receive(:print).with("      create  \n")
       shell.say_status(:create, "")
     end
 
     it "does not print a message if base is muted" do
       expect(shell).to receive(:mute?).and_return(true)
-      expect($stdout).not_to receive(:puts)
+      expect($stdout).not_to receive(:print)
 
       shell.mute do
         shell.say_status(:created, "~/.thor/command.thor")
@@ -133,19 +133,19 @@ describe Thor::Shell::Basic do
       base = MyCounter.new [1,2]
       expect(base).to receive(:options).and_return(:quiet => true)
 
-      expect($stdout).not_to receive(:puts)
+      expect($stdout).not_to receive(:print)
       shell.base = base
       shell.say_status(:created, "~/.thor/command.thor")
     end
 
     it "does not print a message if log status is set to false" do
-      expect($stdout).not_to receive(:puts)
+      expect($stdout).not_to receive(:print)
       shell.say_status(:created, "~/.thor/command.thor", false)
     end
 
     it "uses padding to set message's left margin" do
       shell.padding = 2
-      expect($stdout).to receive(:puts).with("      create      ~/.thor/command.thor")
+      expect($stdout).to receive(:print).with("      create      ~/.thor/command.thor\n")
       shell.say_status(:create, "~/.thor/command.thor")
     end
   end
@@ -293,7 +293,7 @@ TABLE
 
     it "quits if the user chooses quit" do
       allow($stdout).to receive(:print)
-      expect($stdout).to receive(:puts).with('Aborting...')
+      expect($stdout).to receive(:print).with("Aborting...\n")
       expect($stdin).to receive(:gets).and_return('q')
 
       expect {

--- a/spec/shell/html_spec.rb
+++ b/spec/shell/html_spec.rb
@@ -24,9 +24,8 @@ describe Thor::Shell::HTML do
 
   describe "#say_status" do
     it "uses color to say status" do
-      expect($stdout).to receive(:puts).with('<span style="color: red; font-weight: bold;">    conflict</span>  README')
+      expect($stdout).to receive(:print).with("<span style=\"color: red; font-weight: bold;\">    conflict</span>  README\n")
       shell.say_status :conflict, "README", :red
     end
   end
-
 end


### PR DESCRIPTION
The current `IO.puts` implementation makes two separate writes: one for the message and another for the newline character when necessary.

Having multiple threads calling `puts` can lead to interleaved messages and repeated newlines in the output.

This issue came to my attention when I tried out the new `bundler 1.4.0` with parallel installing support. It would print some messages like the following:

``` console
$ bundle install -j4
Using json (1.8.0)
Using nokogiri (1.5.10)Using rspec-core (2.13.1)

Using rspec-mocks (2.13.1)
Using thor (0.18.1)
...
Your bundle is complete!
```
