### PR TITLE
Make gemnasium badge display actual dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', '>= 0.9'
-gem 'rdoc', '>= 3.9'
+gemspec
 
 group :development do
   gem 'pry'
@@ -16,5 +15,3 @@ group :test do
   gem 'rspec-mocks', '>= 2.12.2'
   gem 'simplecov', :require => false
 end
-
-gemspec

--- a/thor.gemspec
+++ b/thor.gemspec
@@ -4,7 +4,6 @@ $:.unshift lib unless $:.include?(lib)
 require 'thor/version'
 
 Gem::Specification.new do |spec|
-  spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ['Yehuda Katz', 'José Valim']
   spec.description = %q{Thor is a toolkit for building powerful command-line interfaces.}
   spec.email = 'ruby-thor@googlegroups.com'
@@ -21,4 +20,8 @@ Gem::Specification.new do |spec|
   spec.summary = spec.description
   spec.test_files = Dir.glob("spec/**/*")
   spec.version = Thor::VERSION
+
+  spec.add_dependency 'rake', '>= 0.9'
+  spec.add_dependency 'rdoc', '>= 3.9'
+  spec.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
Currently gemnasium's badge is green, but says that there are no any dependencies. In this pull request i've moved `rake` and `rdoc` dependencies from `Gemfile` to `thor.gemspec` that makes it visible for gemnasium and show the actual outdate status.
