### PR TITLE
fix so that exist is allowed to be called in tests

### DIFF
--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -131,7 +131,7 @@ describe Thor::Runner do
 
       # Stub load and save to avoid thor.yaml from being overwritten
       allow(YAML).to receive(:load_file).and_return(@original_yaml)
-      allow(File).to receive(:exists?).with(root_file).and_return(true)
+      allow(File).to receive(:exist?).with(root_file).and_return(true)
       allow(File).to receive(:open).with(root_file, "w")
     end
 


### PR DESCRIPTION
The pull request from a few months ago changing `exists?` calls to `exist?` needed to replicated into the allows in the tests for the runner. Once done all the hashes line up again and the module can be found.
