### PR TITLE
Use mime-types 1.x for Ruby 1.8.7 compatibility.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'coveralls', '>=0.5.7', :require => false
   # mime-types is required indirectly by coveralls
   # needs to be < 2.0 to work with Ruby 1.8.7
-  gem 'mime-types', '~> 1.0'
+  gem 'mime-types', '~> 1.25', :platforms => :ruby_18
   gem 'fakeweb', '>= 1.3'
   gem 'rspec', '>= 2.14'
   gem 'rspec-mocks', '>= 2.12.2'


### PR DESCRIPTION
I think this should fix the 1.8.7 Travis build. Let's see!
