### PR TITLE
Check if numeric value is in enum

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -121,6 +121,7 @@ class Thor
     end
 
     # Check if the peek is numeric format and return a Float or Integer.
+    # Check if the peek is included in enum if enum is provided.
     # Otherwise raises an error.
     #
     def parse_numeric(name)
@@ -130,12 +131,19 @@ class Thor
         fail MalformattedArgumentError, "Expected numeric value for '#{name}'; got #{peek.inspect}"
       end
 
-      $&.index('.') ? shift.to_f : shift.to_i
+      value = $&.index('.') ? shift.to_f : shift.to_i
+        if @switches.is_a?(Hash) && switch = @switches[name]
+          if switch.enum && !switch.enum.include?(value)
+            raise MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
+          end
+        end
+      value
     end
 
     # Parse string:
     # for --string-arg, just return the current value in the pile
     # for --no-string-arg, nil
+    # Check if the peek is included in enum if enum is provided. Otherwise raises an error.
     #
     def parse_string(name)
       if no_or_skip?(name)

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -288,6 +288,13 @@ describe Thor::Options do
         expect(parse('--foo=bar', '--foo', '12')['foo']).to eq('12')
         expect(parse('--foo', '12', '--foo', '13')['foo']).to eq('13')
       end
+
+      it "raises error when value isn't in enum" do
+        enum = %w(apple banana)
+        create :fruit => Thor::Option.new('fruit', :type => :string, :enum => enum)
+        expect{ parse('--fruit', 'orange') }.to raise_error(Thor::MalformattedArgumentError,
+          "Expected '--fruit' to be one of #{enum.join(', ')}; got orange")
+      end
     end
 
     describe 'with :boolean type' do
@@ -393,6 +400,13 @@ describe Thor::Options do
       it "raises error when value isn't numeric" do
         expect { parse('-n', 'foo') }.to raise_error(Thor::MalformattedArgumentError,
                                                      "Expected numeric value for '-n'; got \"foo\"")
+      end
+
+      it "raises error when value isn't in enum" do
+        enum = [1, 2]
+        create :limit => Thor::Option.new('limit', :type => :numeric, :enum => enum)
+        expect{ parse('--limit', '3') }.to raise_error(Thor::MalformattedArgumentError,
+          "Expected '--limit' to be one of #{enum.join(', ')}; got 3")
       end
     end
 


### PR DESCRIPTION
References [#381](https://github.com/erikhuda/thor/issues/381)

Validate if value is included in `enum` for numeric options. 

@sferik let me know if something is missing, wrong or you want to change some lines. I Added a test for string cases as well. Since this validation is the same for strings and numerics, it can be extracted into a private method, what do you think?

Thanks.
