### PR TITLE
Make subcommand help more consistent

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -223,9 +223,14 @@ class Thor # rubocop:disable ClassLength
     end
     alias_method :subtasks, :subcommands
 
+    def subcommand_classes
+      @subcommand_classes ||= {}
+    end
+
     def subcommand(subcommand, subcommand_class)
       subcommands << subcommand.to_s
       subcommand_class.subcommand_help subcommand
+      subcommand_classes[subcommand.to_s] = subcommand_class
 
       define_method(subcommand) do |*args|
         args, opts = Thor::Arguments.split(args)
@@ -472,6 +477,14 @@ class Thor # rubocop:disable ClassLength
 
   desc 'help [COMMAND]', 'Describe available commands or one specific command'
   def help(command = nil, subcommand = false)
-    command ? self.class.command_help(shell, command) : self.class.help(shell, subcommand)
+    if command
+      if self.class.subcommands.include? command
+        self.class.subcommand_classes[command].help(shell, true)
+      else
+        self.class.command_help(shell, command)
+      end
+    else
+      self.class.help(shell, subcommand)
+    end
   end
 end

--- a/spec/subcommand_spec.rb
+++ b/spec/subcommand_spec.rb
@@ -38,6 +38,11 @@ describe Thor do
       expect(output).to eq(sub_help)
     end
 
+    it "the help command on the subcommand and after it should result in the same output" do
+      output = capture(:stdout) { TestSubcommands::Parent.start(%w[sub help])}
+      sub_help = capture(:stdout) { TestSubcommands::Parent.start(%w[help sub])}
+      expect(output).to eq(sub_help)
+    end
   end
 
 end


### PR DESCRIPTION
When a command is being asked for help upon and is in the subcommands
list the subcommand's class is invoked for help instead.

A hash of the subcommand classes was added to facilitate this.

Fixes issue #375 
