### PR TITLE
Only set non-nil Readline.completion_proc.

### DIFF
--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -13,7 +13,10 @@ class Thor
       def readline
         if echo?
           ::Readline.completion_append_character = nil
-          ::Readline.completion_proc = completion_proc
+          # Ruby 1.8.7 does not allow Readline.completion_proc= to receive nil.
+          if complete = completion_proc
+            ::Readline.completion_proc = complete
+          end
           ::Readline.readline(prompt, add_to_history?)
         else
           super

--- a/spec/line_editor/readline_spec.rb
+++ b/spec/line_editor/readline_spec.rb
@@ -23,14 +23,14 @@ describe Thor::LineEditor::Readline do
   describe '#readline' do
     it 'invokes the readline library' do
       expect(::Readline).to receive(:readline).with('> ', true).and_return('foo')
-      expect(::Readline).to receive(:completion_proc=).with(nil)
+      expect(::Readline).not_to receive(:completion_proc=)
       editor = Thor::LineEditor::Readline.new('> ', {})
       expect(editor.readline).to eq('foo')
     end
 
     it 'supports the add_to_history option' do
       expect(::Readline).to receive(:readline).with('> ', false).and_return('foo')
-      expect(::Readline).to receive(:completion_proc=).with(nil)
+      expect(::Readline).not_to receive(:completion_proc=)
       editor = Thor::LineEditor::Readline.new('> ', :add_to_history => false)
       expect(editor.readline).to eq('foo')
     end


### PR DESCRIPTION
This fixes an ArgumentError when running with Ruby 1.8.7. (See https://github.com/bundler/bundler/pull/2764)
