### PR TITLE
document negative option for boolean option

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -85,6 +85,10 @@ class Thor
 
       sample = "[#{sample}]" unless required?
 
+      if boolean?
+        sample << ", [#{dasherize("no-" + human_name)}]" unless name == "force"
+      end
+
       if aliases.empty?
         (' ' * padding) << sample
       else

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -172,11 +172,15 @@ describe Thor::Option do
     end
 
     it 'returns usage for boolean types' do
-      expect(parse(:foo, :boolean).usage).to eq('[--foo]')
+      expect(parse(:foo, :boolean).usage).to eq('[--foo], [--no-foo]')
     end
 
     it 'does not use padding when no aliases are given' do
-      expect(parse(:foo, :boolean).usage).to eq('[--foo]')
+      expect(parse(:foo, :boolean).usage).to eq('[--foo], [--no-foo]')
+    end
+
+    it 'documents a negative option when boolean' do
+      expect(parse(:foo, :boolean).usage).to include('[--no-foo]')
     end
 
     it 'uses banner when supplied' do
@@ -196,6 +200,10 @@ describe Thor::Option do
     describe 'with aliases' do
       it 'does not show the usage between brackets' do
         expect(parse([:foo, '-f', '-b'], :required).usage).to eq('-f, -b, --foo=FOO')
+      end
+
+      it 'does not negate the aliases' do
+        expect(parse([:foo, '-f', '-b'], :boolean).usage).to eq('-f, -b, [--foo], [--no-foo]')
       end
     end
   end


### PR DESCRIPTION
Added test and implementation for options that are boolean to document a
--no-option that is equivalent to passing false.

This is to address issue #377
