### PR TITLE
Allow looking inside engines folder

### DIFF
--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -242,11 +242,13 @@ private
 
     unless skip_lookup
       Pathname.pwd.ascend do |path|
-        thorfiles = Thor::Util.globs_for(path).map { |g| Dir[g] }.flatten
-        break unless thorfiles.empty?
+        thorfiles.push Thor::Util.globs_for(path).map { |g| Dir[g] }.flatten
       end
+      Pathname.new("./engines").children.each do |path|
+        thorfiles.push Thor::Util.globs_for(path).map { |g| Dir[g] }.flatten
+      end
+      thorfiles.flatten!
     end
-
     files  = (relevant_to ? thorfiles_relevant_to(relevant_to) : Thor::Util.thor_root_glob)
     files += thorfiles
     files -= ["#{thor_root}/thor.yml"]


### PR DESCRIPTION
Instead of looking just in one place for thor files, I propose searching also inside engines folder and grab all of them together.

This way, we can split thor tasks for each engine and have these for main application as well in the same place they were before.