### PR TITLE
Template stacktraces

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -113,7 +113,9 @@ class Thor
       context = instance_eval("binding")
 
       create_file destination, nil, config do
-        content = ERB.new(::File.binread(source), nil, "-", "@output_buffer").result(context)
+        content = ERB.new(::File.binread(source), nil, "-", "@output_buffer").tap do | erb |
+          erb.filename = source
+        end.result(context)
         content = block.call(content) if block
         content
       end

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -211,6 +211,18 @@ describe Thor::Actions do
       file = File.join(destination_root, "doc/config.yaml")
       expect(File.exist?(file)).to be true
     end
+
+    it "has proper ERB stacktraces" do
+      error = nil
+      begin
+        action :template, "template/bad_config.yaml.tt"
+      rescue => e
+        error = e
+      end
+
+      expect(error).to be_a NameError
+      expect(error.backtrace.to_s).to include('bad_config.yaml.tt:2')
+    end
   end
 
   describe "when changing existent files" do

--- a/spec/fixtures/template/bad_config.yaml.tt
+++ b/spec/fixtures/template/bad_config.yaml.tt
@@ -1,0 +1,2 @@
+--- Hi from yaml
+<%= unresolved_variable %>


### PR DESCRIPTION
This seems to be all it takes to get the correct filename and line number to show up when there is an error in a .tt template.

Stacktrace before:

```
(erb):7:in `block in template': undefined method `each' for nil:NilClass (NoMethodError)
    from (erb):5:in `each'
    from (erb):5:in `template'
    from /opt/boxen/rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `eval'
    from /opt/boxen/rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `result'
    from /opt/boxen/rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/actions/file_manipulation.rb:116:in `block in template'
```

Stacktrace after:

```
/Users/Thoughtworker/repos/opensource/swagger/swagger-thor/resources/templates/grape/files/app/api.rb.tt:7:in `block in template': undefined method `each' for nil:NilClass (NoMethodError)
    from /Users/Thoughtworker/repos/opensource/swagger/swagger-thor/resources/templates/grape/files/app/api.rb.tt:5:in `each'
    from /Users/Thoughtworker/repos/opensource/swagger/swagger-thor/resources/templates/grape/files/app/api.rb.tt:5:in `template'
    from /opt/boxen/rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `eval'
    from /opt/boxen/rbenv/versions/2.1.0/lib/ruby/2.1.0/erb.rb:850:in `result'
    from /Users/Thoughtworker/repos/opensource/thor/lib/thor/actions/file_manipulation.rb:118:in `block in template'
```
