### PR TITLE
Check the type of the default

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -108,6 +108,21 @@ class Thor
 
     def validate!
       fail ArgumentError, "An option cannot be boolean and required." if boolean? && required?
+      validate_default_type!
+    end
+
+    def validate_default_type!
+      default_type = case @default
+                     when nil
+                       return
+                     when TrueClass, FalseClass
+                       :boolean
+                     when Numeric
+                       :numeric
+                     when Hash, Array, String
+                       @default.class.name.downcase.to_sym
+                     end
+      fail ArgumentError, "An option's default must match its type." unless default_type == @type
     end
 
     def dasherized?

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -135,6 +135,12 @@ describe Thor::Option do
     expect(option).to be_required
   end
 
+  it "raises an error if default is inconsistent with type" do
+    expect do
+      option = option("foo", :type => :numeric, :default => "bar")
+    end.to raise_error(ArgumentError, "An option's default must match its type.")
+  end
+
   it "boolean options cannot be required" do
     expect do
       option("foo", :required => true, :type => :boolean)


### PR DESCRIPTION
Hi,

I think the default option should match the type.  This is a problem I ran into while using Thor.  I had code like this:

``` ruby
method_option :foo, :aliases => '-f', :default => '50', :type => :numeric
```

I expect the default value `'50'` to be a numeric, but of course it was a string. 

Hopefully, this pull request solves the problem. ;-)

Cheers,
Huw.
