### PR TITLE
Add support for `HashWithIndifferentAccess#key?` and its aliases

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -24,6 +24,14 @@ class Thor
         super(convert_key(key), value)
       end
 
+      def key?(key)
+        super(convert_key(key))
+      end
+
+      alias_method :include?, :key?
+      alias_method :has_key?, :key?
+      alias_method :member?, :key?
+
       def delete(key)
         super(convert_key(key))
       end

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -14,6 +14,16 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.delete(:foo)).to eq("bar")
   end
 
+  it "verifies presence of keys independent if they are symbols or strings" do
+    expect(@hash.key?(:foo)).to eq(true)
+    expect(@hash.key?("foo")).to eq(true)
+    expect(@hash.key?(:baz)).to eq(true)
+    expect(@hash.key?("baz")).to eq(true)
+
+    expect(@hash.key?(:qux)).to eq(false)
+    expect(@hash.key?("qux")).to eq(false)
+  end
+
   it "handles magic boolean predicates" do
     expect(@hash.force?).to be true
     expect(@hash.foo?).to be true


### PR DESCRIPTION
This commit adds indifferent versions of `Hash#key?` and its aliases (`Hash#has_key?`, `Hash#include?`, and `Hash#member?`) to `Thor::CoreExt::HashWithIndifferentAccess`.

It works thus:

``` ruby
hash = Thor::CoreExt::HashWithIndifferentAccess.new('foo' => 'bar')
hash.key?('foo') # => true
hash.key?(:foo)  # => true
```

Before this commit, `hash.key?(:foo)` would have returned `false`.
