### PR TITLE
Don't freeze the options hash

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -111,9 +111,7 @@ class Thor
 
       check_requirement!
 
-      assigns = Thor::CoreExt::HashWithIndifferentAccess.new(@assigns)
-      assigns.freeze
-      assigns
+      Thor::CoreExt::HashWithIndifferentAccess.new(@assigns)
     end
 
     def check_unknown!


### PR DESCRIPTION
I couldn't figure out why freezing the options hash was a good idea. Any reason why the options hash is frozen?

In my case, I want to override an option after it has already been set and instead of using an instance variable I would prefer to just override the options hash.