### PR TITLE
Add indent method to Thor::Shell::Basic

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -34,6 +34,15 @@ class Thor
         @padding = [0, value].max
       end
 
+      # Sets the output padding while executing a block and resets it.
+      #
+      def indent(count = 1, &block)
+        orig_padding = padding
+        self.padding = padding + count
+        yield
+        self.padding = orig_padding
+      end
+
       # Asks something to the user and receives a response.
       #
       # If asked to limit the correct responses, you can pass in an

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -16,6 +16,29 @@ describe Thor::Shell::Basic do
     end
   end
 
+  describe "#indent" do
+    it "sets the padding temporarily" do
+      shell.indent { expect(shell.padding).to eq(1) }
+      expect(shell.padding).to eq(0)
+    end
+
+    it "derives padding from original value" do
+      shell.padding = 6
+      shell.indent { expect(shell.padding).to eq(7) }
+    end
+
+    it "increases the padding when nested" do
+      shell.indent {
+        expect(shell.padding).to eq(1)
+
+        shell.indent {
+          expect(shell.padding).to eq(2)
+        }
+      }
+      expect(shell.padding).to eq(0)
+    end
+  end
+
   describe "#ask" do
     it "prints a message to the user and gets the response" do
       expect(Thor::LineEditor).to receive(:readline).with("Should I overwrite it? ", {}).and_return("Sure")

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -27,6 +27,12 @@ describe Thor::Shell::Basic do
       shell.indent { expect(shell.padding).to eq(7) }
     end
 
+    it "accepts custom indentation amounts" do
+      shell.indent(6) {
+        expect(shell.padding).to eq(6)
+      }
+    end
+
     it "increases the padding when nested" do
       shell.indent {
         expect(shell.padding).to eq(1)


### PR DESCRIPTION
__Example:__

```ruby
say "Hello!"
indent do
  say "I'm indented 2 spaces!"
  indent do
    say "I'm indented 4 spaces!"
    indent(2) { say "I'm indented 8 spaces!"  }
  end
end
say "I'm not indented anymore!"
```

__Output:__
```
Hello!
  I'm indented 2 spaces!
    I'm indented 4 spaces!
        I'm indented 8 spaces!
I'm not indented anymore!
```