### PR TITLE
Add CHANGELOG changes for 0.19.0 and 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.19.1, release 2014-03-24
+* Fix `say` non-String break regression
+
 ## 0.19.0, release 2014-03-22
 * Add support for a default to #ask
 * Avoid @namespace not initialized warning


### PR DESCRIPTION
I went through the commits between releases and tried my best to capture all of the fixes and features that were not things like docs, code consistency changes, or spec related. I may have missed a few things, but I think I captured most of the public API-ish stuff.

Closes #409 
