### PR TITLE
Issue #455 - only allow a hash key to be specified once

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -99,6 +99,7 @@ class Thor
 
       while current_is_value? && peek.include?(":")
         key, value = shift.split(":", 2)
+        fail MalformattedArgumentError, "You can't specify '#{key}' more than once in option '#{name}'; got #{key}:#{hash[key]} and #{key}:#{value}" if hash.include? key
         hash[key] = value
       end
       hash

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -292,8 +292,7 @@ describe Thor::Options do
       it "raises error when value isn't in enum" do
         enum = %w[apple banana]
         create :fruit => Thor::Option.new("fruit", :type => :string, :enum => enum)
-        expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError,
-                                                             "Expected '--fruit' to be one of #{enum.join(', ')}; got orange")
+        expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError)
       end
     end
 
@@ -363,6 +362,10 @@ describe Thor::Options do
 
       it "must not mix values with other switches" do
         expect(parse("--attributes", "name:string", "age:integer", "--baz", "cool")["attributes"]).to eq("name" => "string", "age" => "integer")
+      end
+
+      it "must not allow the same hash key to be specified multiple times" do
+        expect {parse("--attributes", "name:string", "name:integer")}.to raise_error(Thor::MalformattedArgumentError, "You can't specify 'name' more than once in option '--attributes'; got name:string and name:integer")
       end
     end
 

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -292,7 +292,8 @@ describe Thor::Options do
       it "raises error when value isn't in enum" do
         enum = %w[apple banana]
         create :fruit => Thor::Option.new("fruit", :type => :string, :enum => enum)
-        expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError)
+        expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError,
+            "Expected '--fruit' to be one of #{enum.join(', ')}; got orange")
       end
     end
 


### PR DESCRIPTION
Just a small update to validate a user only enters a key for a hash option at most once. Issue #455 