### PR TITLE
Negative options

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -86,7 +86,7 @@ class Thor
       sample = "[#{sample}]" unless required?
 
       if boolean?
-        sample << ", [#{dasherize("no-" + human_name)}]" unless name == "force"
+        sample << ", [#{dasherize("no-" + human_name)}]" unless name == "force" or name.start_with?("no-")
       end
 
       if aliases.empty?

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -189,6 +189,14 @@ describe Thor::Option do
       expect(parse(:foo, :boolean).usage).to include("[--no-foo]")
     end
 
+    it "does not document a negative option for a negative boolean" do
+      expect(parse(:'no-foo', :boolean).usage).not_to include("[--no-no-foo]")
+    end
+
+    it "documents a negative option for a positive boolean starting with 'no'" do
+      expect(parse(:'nougat', :boolean).usage).to include("[--no-nougat]")
+    end
+
     it "uses banner when supplied" do
       expect(option(:foo, :required => false, :type => :string, :banner => "BAR").usage).to eq("[--foo=BAR]")
     end


### PR DESCRIPTION
Do not generate a negative option (--no-no-foo) for already negative boolean options (--no-foo)