### PR TITLE
Add ability to disable class options for a command

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -156,6 +156,10 @@ class Thor # rubocop:disable ClassLength
     end
     alias_method :option, :method_option
 
+    def disable_class_options
+      @disable_class_options = true
+    end
+
     # Prints help information for the given command.
     #
     # ==== Parameters
@@ -380,11 +384,12 @@ class Thor # rubocop:disable ClassLength
       @usage ||= nil
       @desc ||= nil
       @long_desc ||= nil
+      @disable_class_options ||= nil
 
       if @usage && @desc
         base_class = @hide ? Thor::HiddenCommand : Thor::Command
-        commands[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options)
-        @usage, @desc, @long_desc, @method_options, @hide = nil
+        commands[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options, @disable_class_options)
+        @usage, @desc, @long_desc, @method_options, @hide, @disable_class_options = nil
         true
       elsif all_commands[meth] || meth == "method_missing"
         true
@@ -470,6 +475,7 @@ class Thor # rubocop:disable ClassLength
   map HELP_MAPPINGS => :help
 
   desc "help [COMMAND]", "Describe available commands or one specific command"
+  disable_class_options
   def help(command = nil, subcommand = false)
     if command
       if self.class.subcommands.include? command

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -42,7 +42,7 @@ class Thor
     # config<Hash>:: Configuration for this Thor class.
     #
     def initialize(args = [], local_options = {}, config = {}) # rubocop:disable MethodLength
-      parse_options = self.class.class_options
+      parse_options = config[:current_command] && config[:current_command].disable_class_options ? {} : self.class.class_options
 
       # The start method splits inbound arguments at the first argument
       # that looks like an option (starts with - or --). It then calls

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -1,9 +1,9 @@
 class Thor
-  class Command < Struct.new(:name, :description, :long_description, :usage, :options)
+  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :disable_class_options)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
-    def initialize(name, description, long_description, usage, options = nil)
-      super(name.to_s, description, long_description, usage, options || {})
+    def initialize(name, description, long_description, usage, options = nil, disable_class_options = false)
+      super(name.to_s, description, long_description, usage, options || {}, disable_class_options)
     end
 
     def initialize_copy(other) #:nodoc:

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -422,6 +422,23 @@ HELP
         expect(capture(:stdout) { MyScript.start(%w[help foo]) }).to match(/Usage:/)
       end
     end
+
+    context "with required class_options" do
+      let(:klass) do
+        Class.new(Thor) do
+          class_option :foo, :required => true
+
+          desc "bar", "do something"
+          def bar
+          end
+        end
+      end
+
+      it "shows the command help" do
+        content = capture(:stdout) { klass.start(%w{help}) }
+        expect(content).to match(/Commands:/)
+      end
+    end
   end
 
   describe "when creating commands" do


### PR DESCRIPTION
This is added so the class options can be disabled for the help command. Fixes #363