### PR TITLE
fix subcommand method help

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -234,6 +234,9 @@ class Thor # rubocop:disable ClassLength
         args.unshift("help") if opts.include? "--help" or opts.include? "-h"
         invoke subcommand_class, args, opts, :invoked_via_subcommand => true, :class_options => options
       end
+      subcommand_class.commands.each do |meth, command|
+        command.ancestor_name = subcommand
+      end
     end
     alias_method :subtask, :subcommand
 

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -476,7 +476,8 @@ class Thor
       alias_method :handle_no_task_error, :handle_no_command_error
 
       def handle_argument_error(command, error, args, arity) #:nodoc:
-        msg = "ERROR: \"#{basename} #{command.name}\" was called with "
+        name = [command.ancestor_name, command.name].compact.join(" ")
+        msg = "ERROR: \"#{basename} #{name}\" was called with "
         msg << "no arguments"               if     args.empty?
         msg << "arguments " << args.inspect unless args.empty?
         msg << "\nUsage: #{banner(command).inspect}"

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -1,5 +1,5 @@
 class Thor
-  class Command < Struct.new(:name, :description, :long_description, :usage, :options)
+  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :ancestor_name)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
     def initialize(name, description, long_description, usage, options = nil)
@@ -39,11 +39,13 @@ class Thor
     # Returns the formatted usage by injecting given required arguments
     # and required options into the given usage.
     def formatted_usage(klass, namespace = true, subcommand = false)
-      if namespace
+      if ancestor_name
+        formatted = "#{ancestor_name} " # add space
+      elsif namespace
         namespace = klass.namespace
         formatted = "#{namespace.gsub(/^(default)/, '')}:"
       end
-      formatted = "#{klass.namespace.split(':').last} " if subcommand
+      formatted ||= "#{klass.namespace.split(':').last} " if subcommand
 
       formatted ||= ""
 

--- a/spec/register_spec.rb
+++ b/spec/register_spec.rb
@@ -187,7 +187,7 @@ describe ".register-ing a Thor subclass" do
       begin
         $thor_runner = false
         help_output = capture(:stdout) { BoringVendorProvidedCLI.start(%w[exciting]) }
-        expect(help_output).to include("thor exciting_plugin_c_l_i fireworks")
+        expect(help_output).to include("thor exciting fireworks")
       ensure
         $thor_runner = true
       end

--- a/spec/subcommand_spec.rb
+++ b/spec/subcommand_spec.rb
@@ -45,4 +45,27 @@ describe Thor do
     end
   end
 
+  context "subcommand with an arg" do
+
+    module SubcommandTest1
+      class Child1 < Thor
+        desc "foo NAME", "Fooo"
+        def foo(name)
+          puts "#{name} was given"
+        end
+      end
+
+      class Parent < Thor
+        desc "child1", "child1 description"
+        subcommand "child1", Child1
+      end
+    end
+
+    it "shows subcommand name and method name" do
+      sub_help = capture(:stderr) { SubcommandTest1::Parent.start(%w[child1 foo]) }
+      expect(sub_help).to eq ['ERROR: "thor child1 foo" was called with no arguments', 'Usage: "thor child1 foo NAME"', ''].join("\n")
+    end
+
+  end
+
 end


### PR DESCRIPTION
If these classes are defined,

```
module SubcommandTest1
  class Child1 < Thor
    desc "foo NAME", "Fooo"
    def foo(name)
      puts "#{name} was given"
    end
  end

  class Parent < Thor
    desc "child1", "child1 description"
    subcommand "child1", Child1
  end
end
```

`SubcommandTest1::Parent.start(%w[child1 foo])` puts messages to $stderr

on current master 

```
ERROR: "thor foo" was called with no arguments
Usage: "thor subcommand_test1:child1:foo NAME"
```

on this pull request branch

```
ERROR: "thor child1 foo" was called with no arguments
Usage: "thor child1 foo NAME"
```
