### PR TITLE
Add support for repeatable options

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -1,16 +1,17 @@
 class Thor
   class Option < Argument #:nodoc:
-    attr_reader :aliases, :group, :lazy_default, :hide
+    attr_reader :aliases, :group, :lazy_default, :hide, :repeatable
 
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
     def initialize(name, options = {})
       options[:required] = false unless options.key?(:required)
       super
-      @lazy_default = options[:lazy_default]
-      @group        = options[:group].to_s.capitalize if options[:group]
-      @aliases      = Array(options[:aliases])
-      @hide         = options[:hide]
+      @lazy_default   = options[:lazy_default]
+      @group          = options[:group].to_s.capitalize if options[:group]
+      @aliases        = Array(options[:aliases])
+      @hide           = options[:hide]
+      @repeatable     = options.fetch(:repeatable, false)
     end
 
     # This parse quick options given as method_options. It makes several

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -92,7 +92,13 @@ class Thor
 
             switch = normalize_switch(switch)
             option = switch_option(switch)
-            @assigns[option.human_name] = parse_peek(switch, option)
+            result = parse_peek(switch, option)
+
+            if option.repeatable
+              (@assigns[option.human_name] ||= []) << result
+            else
+              @assigns[option.human_name] = result
+            end
           elsif @stop_on_unknown
             @parsing_options = false
             @extra << shifted

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -289,6 +289,13 @@ describe Thor::Options do
         expect(parse("--foo", "12", "--foo", "13")["foo"]).to eq("13")
       end
 
+      it "allows multiple values if repeatable is specified" do
+        create :foo => Thor::Option.new("foo", :type => :string, :repeatable => true)
+
+        expect(parse("--foo=bar", "--foo", "12")["foo"]).to eq(["bar", "12"])
+        expect(parse("--foo", "13", "--foo", "14")["foo"]).to eq(["bar", "12", "13", "14"])
+      end
+
       it "raises error when value isn't in enum" do
         enum = %w[apple banana]
         create :fruit => Thor::Option.new("fruit", :type => :string, :enum => enum)
@@ -346,6 +353,12 @@ describe Thor::Options do
         expect(parse("--foo", "bar")).to eq("foo" => true)
         expect(@opt.remaining).to eq(%w[bar])
       end
+
+      it "allows multiple values if repeatable is specified" do
+        create :verbose => Thor::Option.new("verbose", :type => :boolean, :aliases => '-v', :repeatable => true)
+
+        expect(parse("-v", "-v", "-v")["verbose"].count).to eq(3)
+      end
     end
 
     describe "with :hash type" do
@@ -368,6 +381,13 @@ describe Thor::Options do
       it "must not allow the same hash key to be specified multiple times" do
         expect {parse("--attributes", "name:string", "name:integer")}.to raise_error(Thor::MalformattedArgumentError, "You can't specify 'name' more than once in option '--attributes'; got name:string and name:integer")
       end
+
+      it "allows multiple values if repeatable is specified" do
+        create :attributes => Thor::Option.new("attributes", :type => :hash, :repeatable => true)
+
+        expect(parse("--attributes", "name:one", "age:1", "--attributes", "name:two", "age:2")["attributes"]).to eq([{"name"=>"one", "age"=>"1"},
+                                                                                                                     {"name"=>"two", "age"=>"2"}])
+      end
     end
 
     describe "with :array type" do
@@ -385,6 +405,12 @@ describe Thor::Options do
 
       it "must not mix values with other switches" do
         expect(parse("--attributes", "a", "b", "c", "--baz", "cool")["attributes"]).to eq(%w[a b c])
+      end
+
+      it "allows multiple values if repeatable is specified" do
+        create :attributes => Thor::Option.new("attributes", :type => :array, :repeatable => true)
+
+        expect(parse("--attributes", "1", "2", "--attributes", "3", "4")["attributes"]).to eq([["1", "2"], ["3", "4"]])
       end
     end
 
@@ -411,6 +437,12 @@ describe Thor::Options do
         create :limit => Thor::Option.new("limit", :type => :numeric, :enum => enum)
         expect { parse("--limit", "3") }.to raise_error(Thor::MalformattedArgumentError,
                                                         "Expected '--limit' to be one of #{enum.join(', ')}; got 3")
+      end
+
+      it "allows multiple values if repeatable is specified" do
+        create :run => Thor::Option.new("run", :type => :numeric, :repeatable => true)
+
+        expect(parse("--run", "1", "--run", "2")["run"]).to eq([1, 2])
       end
     end
 


### PR DESCRIPTION
If an option is marked as `:repeatable => true`, then its value is an array of values.
###### Hash

``` ruby
option :item, :type => :hash, :repeatable => true
```

```
$ mycmd --item name:one age:1 --item name:two age:2
```

``` ruby
options[:item] = [{"name" => "one", ...}, {"name" => "two", ...}]
```
###### Array

``` ruby
option :item, :type => :array, :repeatable => true
```

```
$ mycmd --item 1 2 3 --item 4 5 6
```

``` ruby
options[:item] = [["1", "2", "3"], ["4", "5", "6"]]
```

**Note:** This patch is backward-compatible, because options must be marked explicitly with `:repeatable`.
