### PR TITLE
Add #fetch to HashWithIndifferentAccess

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -28,6 +28,10 @@ class Thor
         super(convert_key(key))
       end
 
+      def fetch(key, *args)
+        super(convert_key(key), *args)
+      end
+
       def values_at(*indices)
         indices.map { |key| self[convert_key(key)] }
       end

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -14,6 +14,13 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.delete(:foo)).to eq("bar")
   end
 
+  it "supports fetch" do
+    expect(@hash.fetch("foo")).to eq("bar")
+    expect(@hash.fetch("foo", nil)).to eq("bar")
+    expect(@hash.fetch(:foo)).to eq("bar")
+    expect(@hash.fetch(:foo, nil)).to eq("bar")
+  end
+
   it "handles magic boolean predicates" do
     expect(@hash.force?).to be true
     expect(@hash.foo?).to be true


### PR DESCRIPTION
I ran into surprising behavior when `options[:foo] || 123` worked as expected, but switching to `options.fetch(:foo, 123)` always resulted in `123`.

I know that defaults should be set in option/method_option, but the class that I'm instantiating is used by other clients than Thor.