### PR TITLE
remove special handling of inverse boolean flags

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -55,11 +55,6 @@ class Thor
 
   private
 
-    def no_or_skip?(arg)
-      arg =~ /^--(no|skip)-([-\w]+)$/
-      $2
-    end
-
     def last?
       @pile.empty?
     end
@@ -143,21 +138,16 @@ class Thor
 
     # Parse string:
     # for --string-arg, just return the current value in the pile
-    # for --no-string-arg, nil
     # Check if the peek is included in enum if enum is provided. Otherwise raises an error.
     #
     def parse_string(name)
-      if no_or_skip?(name)
-        nil
-      else
-        value = shift
-        if @switches.is_a?(Hash) && switch = @switches[name] # rubocop:disable AssignmentInCondition
-          if switch.enum && !switch.enum.include?(value)
-            fail MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
-          end
+      value = shift
+      if @switches.is_a?(Hash) && switch = @switches[name] # rubocop:disable AssignmentInCondition
+        if switch.enum && !switch.enum.include?(value)
+          fail MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
         end
-        value
       end
+      value
     end
 
     # Raises an error if @non_assigned_required array is not empty.

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -85,10 +85,6 @@ class Thor
 
       sample = "[#{sample}]" unless required?
 
-      if boolean?
-        sample << ", [#{dasherize("no-" + human_name)}]" unless name == "force" or name.start_with?("no-")
-      end
-
       if aliases.empty?
         (" " * padding) << sample
       else

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -157,11 +157,7 @@ class Thor
     end
 
     def switch_option(arg)
-      if match = no_or_skip?(arg) # rubocop:disable AssignmentInCondition
-        @switches[arg] || @switches["--#{match}"]
-      else
-        @switches[arg]
-      end
+      @switches[arg]
     end
 
     # Check if the given argument is actually a shortcut.
@@ -175,7 +171,7 @@ class Thor
       @parsing_options
     end
 
-    # Parse boolean values which can be given as --foo=true, --foo or --no-foo.
+    # Parse boolean values which can be given as --foo=true or --foo.
     #
     def parse_boolean(switch)
       if current_is_value?
@@ -189,7 +185,7 @@ class Thor
           true
         end
       else
-        @switches.key?(switch) || !no_or_skip?(switch)
+        @switches.key?(switch)
       end
     end
 
@@ -199,8 +195,6 @@ class Thor
       if parsing_options? && (current_is_switch_formatted? || last?)
         if option.boolean?
           # No problem for boolean types
-        elsif no_or_skip?(switch)
-          return nil # User set value to nil
         elsif option.string? && !option.required?
           # Return the default if there is one, else the human name
           return option.lazy_default || option.default || option.human_name

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -116,10 +116,6 @@ describe Thor::Group do
         expect(@content).to match(/1\n2\n3\n4\n5\n/)
       end
 
-      it "does not invoke if the option is nil" do
-        expect(capture(:stdout) { G.start(%w[--skip-invoked]) }).not_to match(/invoke/)
-      end
-
       it "prints a message if invocation cannot be found" do
         content = capture(:stdout) { G.start(%w[--invoked unknown]) }
         expect(content).to match(/error  unknown \[not found\]/)
@@ -159,10 +155,6 @@ describe Thor::Group do
 
       it "allows to invoke a class from the class binding by a default option" do
         expect(@content).to match(/1\n2\n3\n4\n5\n/)
-      end
-
-      it "does not invoke if the option is false" do
-        expect(capture(:stdout) { H.start(%w[--no-defined]) }).not_to match(/invoke/)
       end
 
       it "shows invocation information to the user" do

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -178,23 +178,7 @@ describe Thor::Option do
     end
 
     it "returns usage for boolean types" do
-      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo]")
-    end
-
-    it "does not use padding when no aliases are given" do
-      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo]")
-    end
-
-    it "documents a negative option when boolean" do
-      expect(parse(:foo, :boolean).usage).to include("[--no-foo]")
-    end
-
-    it "does not document a negative option for a negative boolean" do
-      expect(parse(:'no-foo', :boolean).usage).not_to include("[--no-no-foo]")
-    end
-
-    it "documents a negative option for a positive boolean starting with 'no'" do
-      expect(parse(:'nougat', :boolean).usage).to include("[--no-nougat]")
+      expect(parse(:foo, :boolean).usage).to eq("[--foo]")
     end
 
     it "uses banner when supplied" do
@@ -214,10 +198,6 @@ describe Thor::Option do
     describe "with aliases" do
       it "does not show the usage between brackets" do
         expect(parse([:foo, "-f", "-b"], :required).usage).to eq("-f, -b, --foo=FOO")
-      end
-
-      it "does not negate the aliases" do
-        expect(parse([:foo, "-f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo]")
       end
     end
   end

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -128,7 +128,6 @@ describe Thor::Options do
     it "accepts underscores in commandline args hash for boolean" do
       create :foo_bar => :boolean
       expect(parse("--foo_bar")["foo_bar"]).to eq(true)
-      expect(parse("--no_foo_bar")["foo_bar"]).to eq(false)
     end
 
     it "accepts underscores in commandline args hash for strings" do
@@ -264,11 +263,6 @@ describe Thor::Options do
         expect(parse("--foo_bar=http://example.com/under_score/")["foo_bar"]).to eq("http://example.com/under_score/")
       end
 
-      it "accepts a --no-switch format" do
-        create "--foo" => "bar"
-        expect(parse("--no-foo")["foo"]).to be nil
-      end
-
       it "does not consume an argument for --no-switch format" do
         create "--cheese" => :string
         expect(parse("burger", "--no-cheese", "fries")["cheese"]).to be nil
@@ -337,8 +331,6 @@ describe Thor::Options do
       it "accepts inputs in the human name format" do
         create :foo_bar => :boolean
         expect(parse("--foo-bar")["foo_bar"]).to eq(true)
-        expect(parse("--no-foo-bar")["foo_bar"]).to eq(false)
-        expect(parse("--skip-foo-bar")["foo_bar"]).to eq(false)
       end
 
       it "doesn't eat the next part of the param" do


### PR DESCRIPTION
:warning: **WIP** :warning: 

Closes https://github.com/erikhuda/thor/issues/417#issuecomment-45052020.

This is a superset of #473, removing all special handling of boolean flags generating/parsing the inverse. It certainly makes the behavior more straightforward (no magic flags), though I realize checks for "negative" flags (like `options[:no_public] == true`) become a little more confusing. Thoughts? Also, I'm new to this codebase, so while all tests are passing, would love another set of :eyes: to ensure I got everything.
