### PR TITLE
Add key? method for improving ::Hash compatibility

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -28,6 +28,10 @@ class Thor
         super(convert_key(key))
       end
 
+      def key?(key)
+        super(convert_key(key))
+      end
+
       def values_at(*indices)
         indices.map { |key| self[convert_key(key)] }
       end

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -14,6 +14,14 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.delete(:foo)).to eq("bar")
   end
 
+  it "has key checkable by either strings or symbols" do
+    expect(@hash.key?("foo")).to be true
+    expect(@hash.key?(:foo)).to be true
+
+    expect(@hash.key?("nothing")).to be false
+    expect(@hash.key?(:nothing)).to be false
+  end
+
   it "handles magic boolean predicates" do
     expect(@hash.force?).to be true
     expect(@hash.foo?).to be true


### PR DESCRIPTION
options (HashWithIndifferentAccess) has key checkable by either strings or symbols