### PR TITLE
fix 'thor_script subcommand [args] --help' 🌈 

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -235,8 +235,11 @@ class Thor # rubocop:disable ClassLength
 
       define_method(subcommand) do |*args|
         args, opts = Thor::Arguments.split(args)
-        args.unshift("help") if opts.include? "--help" or opts.include? "-h"
-        invoke subcommand_class, args, opts, :invoked_via_subcommand => true, :class_options => options
+        invoke_args = [args, opts, Hash[:invoked_via_subcommand => true, :class_options => options]]
+        if opts.delete('--help') or opts.delete("-h")
+            invoke_args.unshift 'help'
+        end
+        invoke subcommand_class, *invoke_args
       end
     end
     alias_method :subtask, :subcommand

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -441,6 +441,18 @@ HELP
     end
   end
 
+  describe "subcommands" do
+    it "triggers a subcommand help when passed --help" do
+      parent = Class.new(Thor)
+      child  = Class.new(Thor)
+      parent.desc 'child', 'child subcommand'
+      parent.subcommand 'child', child
+      parent.desc 'dummy', 'dummy'
+      expect(child).to receive(:help).with(anything, anything)
+      parent.start ['child', '--help']
+    end
+  end
+
   describe "when creating commands" do
     it "prints a warning if a public method is created without description or usage" do
       expect(capture(:stdout) do


### PR DESCRIPTION
Currently, doing so leads to

    [~/dev/flat_fish]% autoproj test --help
    Usage:
      autoproj help [COMMAND]

instead of the expected result of "autoproj help test"

This case is handled internally by thor by transforming the subcommand invocation into `help *ARGV`

There were two problems:
 - first invoke was called with (klass, args, options, parameters) while invoke expects (klass, subcommand, args, options, parameters)
 - the --help argument was kept, which ends up as `help *ARGV --help, i.e. "give me the help of the 'help' subcommand

The commit removes the --help option before calling the subcommand, and fixes the call signature. It only does so for the "massaged" 'help' subcommand because invoke() has a way-too-weird call semantic for me to change the call in the general case without fearing to break something else.