### PR TITLE
install pry-byebug to debug on 2.1 🌈

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'rdoc', '>= 3.9'
 group :development do
   gem 'guard-rspec'
   gem 'pry'
+  platforms :ruby_21 do
+    gem 'pry-byebug'
+  end
   platforms :ruby_19, :ruby_20 do
     gem 'pry-debugger'
     gem 'pry-stack_explorer'


### PR DESCRIPTION
Only to 2.1 as travis does not know about ruby_22 (and the CI build fails then ...)