### PR TITLE
Feature/dont replace nonexistant files

### DIFF
--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -57,7 +57,7 @@ class Thor
           replacement + '\0'
         end
 
-        if exists?
+        if File.exist?(destination)
           replace!(/#{flag}/, content, config[:force])
         else
           raise MalformattedArgumentError, "The file #{ destination } does not appear to exist"

--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -57,7 +57,7 @@ class Thor
           replacement + '\0'
         end
 
-        if File.exist?(destination)
+        if exists?
           replace!(/#{flag}/, content, config[:force])
         else
           raise MalformattedArgumentError, "The file #{ destination } does not appear to exist"

--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -1,4 +1,5 @@
 require "thor/actions/empty_directory"
+require "pry"
 
 class Thor
   module Actions
@@ -56,7 +57,11 @@ class Thor
           replacement + '\0'
         end
 
-        replace!(/#{flag}/, content, config[:force])
+        if File.exist?(destination)
+          replace!(/#{flag}/, content, config[:force])
+        else
+          raise MalformattedArgumentError, "The file #{ destination } does not appear to exist"
+        end
       end
 
       def revoke!

--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -1,5 +1,4 @@
 require "thor/actions/empty_directory"
-require "pry"
 
 class Thor
   module Actions

--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -59,7 +59,7 @@ class Thor
         if File.exist?(destination)
           replace!(/#{flag}/, content, config[:force])
         else
-          raise MalformattedArgumentError, "The file #{ destination } does not appear to exist"
+          raise Thor::Error, "The file #{ destination } does not appear to exist"
         end
       end
 

--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -71,18 +71,19 @@ describe Thor::Actions::InjectIntoFile do
     end
 
     it "does not attempt to change the file if it doesn't exist" do
-      expect_any_instance_of(Thor::Actions::InjectIntoFile).not_to receive(:replace!)
       invoker.inject_into_file "idontexist", :before => "something" do
         "any content"
       end rescue nil
+
+      expect(File.exist?("idontexist")).to be_falsey
     end
 
-    it "raises a malformatted argument error including filename if file doesn't exist" do
+    it "raises a Thor error including filename if file doesn't exist" do
       expect do
-        invoker.inject_into_file "idontexist", :before => "something" do
+        invoke! "idontexist", :before => "something" do
           "any content"
         end
-      end.to raise_error(Thor::MalformattedArgumentError, /does not appear to exist/)
+      end.to raise_error(Thor::Error, /does not appear to exist/)
     end
 
     it "does change the file if already includes content and :force is true" do

--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -70,6 +70,21 @@ describe Thor::Actions::InjectIntoFile do
       expect(File.read(file)).to eq("__start__\nREADME\nmore content\n__end__\n")
     end
 
+    it "does not attempt to change the file if it doesn't exist" do
+      expect_any_instance_of(Thor::Actions::InjectIntoFile).not_to receive(:replace!)
+      invoker.inject_into_file "idontexist", :before => "something" do
+        "any content"
+      end rescue nil
+    end
+
+    it "raises a malformatted argument error including filename if file doesn't exist" do
+      expect do
+        invoker.inject_into_file "idontexist", :before => "something" do
+          "any content"
+        end
+      end.to raise_error(Thor::MalformattedArgumentError, /does not appear to exist/)
+    end
+
     it "does change the file if already includes content and :force is true" do
       invoke! "doc/README", :before => "__end__" do
         "more content\n"

--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -70,20 +70,13 @@ describe Thor::Actions::InjectIntoFile do
       expect(File.read(file)).to eq("__start__\nREADME\nmore content\n__end__\n")
     end
 
-    it "does not attempt to change the file if it doesn't exist" do
-      invoker.inject_into_file "idontexist", :before => "something" do
-        "any content"
-      end rescue nil
-
-      expect(File.exist?("idontexist")).to be_falsey
-    end
-
-    it "raises a Thor error including filename if file doesn't exist" do
+    it "does not attempt to change the file if it doesn't exist - instead raises Thor::Error" do
       expect do
-        invoke! "idontexist", :before => "something" do
-          "any content"
-        end
+	invoke! "idontexist", :before => "something" do
+	  "any content"
+	end
       end.to raise_error(Thor::Error, /does not appear to exist/)
+      expect(File.exist?("idontexist")).to be_falsey
     end
 
     it "does change the file if already includes content and :force is true" do


### PR DESCRIPTION
🌈
^ the rainbow of compliance :)

I came across some difficulty earlier today as a rails generator was attempting to inject into a file that didn't exist in my project. The error was relatively clear but I was surprised to find that Thor didn't handle this issue. My pull request helps that a little, hopefully, and would address at least [this guy's](https://github.com/erikhuda/thor/issues/463) issue.
Please let me know if the specs are inadequate or if this needs documentation.
