### PR TITLE
replaced '.map{|_,o| o}' on hash with '.values'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 group :test do
   gem 'childlabor'
   gem 'coveralls', '>= 0.5.7'
+  gem 'addressable', '~> 2.3.6', :platforms => [:ruby_18]
   gem 'webmock', '>= 1.20'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 3'

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -174,7 +174,7 @@ class Thor # rubocop:disable ClassLength
       shell.say "Usage:"
       shell.say "  #{banner(command)}"
       shell.say
-      class_options_help(shell, nil => command.options.map { |_, o| o })
+      class_options_help(shell, nil => command.options.values)
       if command.long_description
         shell.say "Description:"
         shell.print_wrapped(command.long_description, :indent => 2)


### PR DESCRIPTION
The values of a hash someplace were being obtained using a non-standard method, as if the hash was a 2D array. This has been replaced with the `.values` method now. Tests have been checked locally on Ruby version 2.2.3. They're passing. Travis will execute them on remaining environments.