### PR TITLE
specify addressable version on ruby 1.8.7 platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 group :test do
   gem 'childlabor'
   gem 'coveralls', '>= 0.5.7'
+  gem 'addressable', '~> 2.3.6', :platforms => [:ruby_18]
   gem 'webmock', '>= 1.20'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 3'


### PR DESCRIPTION
webmock required addressable version 2.3.6 or greater. a later
has now required minimum ruby version to be 1.9. this commit
specified which addressable version to use to travis tests pass
while using ruby 1.8.7