### PR TITLE
Use block instead of to_proc

### DIFF
--- a/lib/thor/line_editor/basic.rb
+++ b/lib/thor/line_editor/basic.rb
@@ -23,7 +23,9 @@ class Thor
         if echo?
           $stdin.gets
         else
-          $stdin.noecho(&:gets)
+          $stdin.noecho do |stdin|
+            stdin.gets
+          end
         end
       end
 


### PR DESCRIPTION
Test suite stops at `$stdin.noecho(&:gets)` with Ruby 2.3 (ruby-head build on travis CI).
When I changed it to `$stdin.noecho { |stdin| stdin.gets }`, it worked somehow.
But I don't know why... :(