### PR TITLE
Fixed two raise_error warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ matrix:
   fast_finish: true
 script: bundle exec thor spec
 sudo: false
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', '>= 0.9'
+gem 'rake', '>= 0.9', '< 11.0'
 gem 'rdoc', '>= 3.9'
 
 group :development do

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -121,7 +121,7 @@ describe Thor::Actions do
 
       it "finds a template inside the source path" do
         expect(runner.find_in_source_paths("doc")).to eq(File.expand_path("doc", source_root))
-        expect { runner.find_in_source_paths("README") }.to raise_error
+        expect { runner.find_in_source_paths("README") }.to raise_error(Thor::Error)
 
         new_path = File.join(source_root, "doc")
         runner.instance_variable_set(:@source_paths, nil)

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -28,7 +28,7 @@ describe Thor::Group do
     end
 
     it "raises when an exception happens within the command call" do
-      expect { BrokenCounter.start(%w[1 2 --fail]) }.to raise_error
+      expect { BrokenCounter.start(%w[1 2 --fail]) }.to raise_error(NameError)
     end
 
     it "raises an error when a Thor group command expects arguments" do


### PR DESCRIPTION
 🌈
Fixed 2 **Using the `raise_error` matcher without providing a specific error**
messages in spec/actions_spec.rb and spec/group_spec.rb files.

Used "bundle exec rspec" to run the specs.

After failed TravisCI build, restricted rake gem to < 11.0 for now.