### PR TITLE
Support all command names and incremental numerical arguments

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -331,7 +331,9 @@ class Thor # rubocop:disable ClassLength
     # The method responsible for dispatching given the args.
     def dispatch(meth, given_args, given_opts, config) #:nodoc: # rubocop:disable MethodLength
       meth ||= retrieve_command_name(given_args)
-      command = all_commands[normalize_command_name(meth)]
+      # Initially search for a direct command match. If that's not found,
+      # search for the normalized name.
+      command = all_commands[meth] || all_commands[normalize_command_name(meth)]
 
       if !command && config[:invoked_via_subcommand]
         # We're a subcommand and our first argument didn't match any of our

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -1,6 +1,6 @@
 class Thor
   class Option < Argument #:nodoc:
-    attr_reader :aliases, :group, :lazy_default, :hide
+    attr_reader :aliases, :group, :lazy_default, :hide, :incremental
 
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
@@ -11,6 +11,14 @@ class Thor
       @group        = options[:group].to_s.capitalize if options[:group]
       @aliases      = Array(options[:aliases])
       @hide         = options[:hide]
+      @incremental  = options[:incremental]
+    end
+
+    # Is this numeric option incremental?
+    #
+    # e.g. -vvv = 3
+    def incremental?
+      numeric? && incremental
     end
 
     # This parse quick options given as method_options. It makes several


### PR DESCRIPTION
- Support non-normalized command names (including hyphens). Commands map directly to methods, so as long as you can define the method (with regular `def` syntax or using `define_method`), you can call it through the command line.
- Support incremental numerical arguments. If `--verbosity` is an option of type `:numerical` with an alias of `-v`, you can set the verbosity by incrementing the number of short flags you pass. For example, `-vvv` would set the verbosity of 3.