### PR TITLE
Display name of option which does not have a default value that match…

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -124,7 +124,7 @@ class Thor
                      when Hash, Array, String
                        @default.class.name.downcase.to_sym
                      end
-      fail ArgumentError, "An option's default must match its type." unless default_type == @type
+      fail ArgumentError, "Option #{human_name}'s default must match its type." unless default_type == @type
     end
 
     def dasherized?


### PR DESCRIPTION
Makes warning/error output more useful.

Old functionality:

```
WARNING: unable to load thorfile "abc_aws.thor": An option's default must match its type.
/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/thor/lib/thor/parser/option.rb:127:in `validate_default_type!'
```

New functionality shows errored option name:

```
WARNING: unable to load thorfile "abc_aws.thor":  Option wait_delay_secs's default must match its type.
/rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/thor/lib/thor/parser/option.rb:127:in `validate_default_type!'
```
