### PR TITLE
Make HashWithIndifferentAccess fail gracefully...

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -305,14 +305,18 @@ class Thor
       super.merge!(:destination_root => destination_root)
     end
 
+    FORCE_SKIP_OPPOSITES ||= { force: "skip", skip: "force" }.freeze
+
     def _cleanup_options_and_set(options, key) #:nodoc:
       case options
       when Array
         %w[--force -f --skip -s].each { |i| options.delete(i) }
         options << "--#{key}"
+        options << "--no-#{FORCE_SKIP_OPPOSITES[key.to_sym]}"
       when Hash
         [:force, :skip, "force", "skip"].each { |i| options.delete(i) }
         options.merge!(key => true)
+        options.merge!(FORCE_SKIP_OPPOSITES[key.to_sym] => false)
       end
     end
   end

--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -77,7 +77,11 @@ class Thor
             self[$1] == args.first
           end
         else
-          self[method]
+          if self.key?(method)
+            self[method]
+          else
+            raise NoMethodError, "undefined method `#{method}' for #{self}"
+          end
         end
       end
     end

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -1,6 +1,11 @@
 require "helper"
 require "thor/core_ext/hash_with_indifferent_access"
 
+class HasMethod < Thor::CoreExt::HashWithIndifferentAccess
+  def this_method_exists
+  end
+end
+
 describe Thor::CoreExt::HashWithIndifferentAccess do
   before do
     @hash = Thor::CoreExt::HashWithIndifferentAccess.new :foo => "bar", "baz" => "bee", :force => true
@@ -39,8 +44,19 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.foo?("bee")).to be false
   end
 
-  it "maps methods to keys" do
-    expect(@hash.foo).to eq(@hash["foo"])
+  context "map methods to keys" do
+    it "succeeds with existing keys" do
+      expect(@hash.foo).to eq(@hash["foo"])
+    end
+
+    it "does not fail silently with missing keys" do
+      expect { @hash.does_not_exist }.to raise_error(NoMethodError)
+    end
+
+    it "prefers methods over keys in derived classes" do
+      @tester = HasMethod.new
+      expect { @tester.this_method_exists }.not_to raise_error
+    end
   end
 
   it "merges keys independent if they are symbols or strings" do


### PR DESCRIPTION
... when trying to access a key as a method, but the key does not exist.

Before this PR, it would simply return nil, i.e.

```ruby
x = HashWithIndifferentAccess.new
x.does_not_exist # would have succeeded without error or warning
```

After this PR:

```ruby
x = HashWithIndifferentAccess.new "foo" => "bar"
x.foo # => "bar"
x.does_not_exist # raises NoMethodError
```
