### PR TITLE
Fix "file clash" bug

### DIFF
--- a/lib/thor/actions/empty_directory.rb
+++ b/lib/thor/actions/empty_directory.rb
@@ -112,11 +112,17 @@ class Thor
         if exists?
           on_conflict_behavior(&block)
         else
-          say_status :create, :green
           yield unless pretend?
+          say_status :create, :green
         end
 
         destination
+      rescue Errno::EISDIR, Errno::EEXIST
+        on_file_clash_behavior
+      end
+
+      def on_file_clash_behavior
+        say_status :file_clash, :red
       end
 
       # What to do when the destination file already exists.

--- a/spec/actions/create_file_spec.rb
+++ b/spec/actions/create_file_spec.rb
@@ -131,6 +131,30 @@ describe Thor::Actions::CreateFile do
         end
       end
     end
+
+    context "when file exists and it causes a file clash" do
+      before do
+        create_file("doc/config")
+        invoke!
+      end
+
+      it "generates a file clash" do
+        create_file("doc/config/config.rb")
+        expect(invoke!).to eq("  file_clash  doc/config/config.rb\n")
+      end
+    end
+
+    context "when directory exists and it causes a file clash" do
+      before do
+        create_file("doc/config/hello")
+        invoke!
+      end
+
+      it "generates a file clash" do
+        create_file("doc/config")
+        expect(invoke!) .to eq("  file_clash  doc/config\n")
+      end
+    end
   end
 
   describe "#revoke!" do


### PR DESCRIPTION
## Summary

In some cases creating a file would raise an exception, due to clashes with existing file. E.g. creating a file where a directory with the same name is present.

## How to reproduce the bug

```
$ mkdir err
$ touch er/hello
$ irb
>> require 'thor'; class A < Thor; include Thor::Actions; end; a = A.new; a.create_file('./err/hello/boom')
      create  err/hello/boom
Errno::EEXIST: File exists @ dir_s_mkdir - /Users/anodari/other_projects/thor/err/hello
from /Users/anodari/.rbenv/versions/2.4.0/lib/ruby/2.4.0/fileutils.rb:228:in `mkdir'
```

## What happen using the bug fix
```
>> require './lib/thor'; class A < Thor; include Thor::Actions; end; a = A.new; a.create_file('./err/hello/boom')
  file_clash  err/hello/boom
```

I would be more than happy to discuss further this issue. Feel free to comment about the naming and the approach.