### PR TITLE
Bug Fix on Windows changing /USER~1/ to /User Name/

### DIFF
--- a/lib/thor/actions/directory.rb
+++ b/lib/thor/actions/directory.rb
@@ -80,6 +80,11 @@ class Thor
         files(lookup).sort.each do |file_source|
           next if File.directory?(file_source)
           next if config[:exclude_pattern] && file_source.match(config[:exclude_pattern])
+
+          # Fix for Windows, turns /USER~1/ into /User Name/ for temp directory so that
+          # gsub will find a match
+          source.gsub!(/\/\w*~1\//, "/"+ENV['USERNAME']+"/")
+
           file_destination = File.join(given_destination, file_source.gsub(source, "."))
           file_destination.gsub!("/./", "/")
 


### PR DESCRIPTION
🌈

This is to fix a bug that I (and others, see [rspec#1555](https://github.com/rspec/rspec-rails/issues/1555), [rspec#1577](https://github.com/rspec/rspec-rails/issues/1577), [rspec#1747](https://github.com/rspec/rspec-rails/issues/1747) and [rails#27129](https://github.com/rails/rails/issues/27129)) have experienced when running `rails generate rspec:install` on a windows machine.

Ruby creates a tmpdir with `/USER~1/` and then thor uses another method, `files(lookup)`, that converts it to `/User Name/` and tries to compare the two and gsub it out when it assigns it to `file_destination`. My fix, though a little hacky (I'm new to Ruby and don't really know of a better way in all honesty) works and shouldn't create problems elsewhere as far as I can see.

