### PR TITLE
Add disable_required_check! and make disable the check in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.20.0
+* Add `disable_required_check!` to disable check for required options in some commands.
+  It is a substitute of `disable_class_options` that was not working as intended.
+
 * Add `inject_into_module`.
 
 ## 0.19.4, release 2016-11-28

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -158,10 +158,6 @@ class Thor
     end
     alias_method :option, :method_option
 
-    def disable_class_options
-      @disable_class_options = true
-    end
-
     # Prints help information for the given command.
     #
     # ==== Parameters
@@ -329,10 +325,29 @@ class Thor
       command && stop_on_unknown_option.include?(command.name.to_sym)
     end
 
+    # Disable the check for required options for the given commands.
+    # This is useful if you have a command that does not need the required options
+    # to work, like help.
+    #
+    # ==== Parameters
+    # Symbol ...:: A list of commands that should be affected.
+    def disable_required_check!(*command_names)
+      disable_required_check.merge(command_names)
+    end
+
+    def disable_required_check?(command) #:nodoc:
+      command && disable_required_check.include?(command.name.to_sym)
+    end
+
   protected
 
     def stop_on_unknown_option #:nodoc:
       @stop_on_unknown_option ||= Set.new
+    end
+
+    # help command has the required check disabled by default.
+    def disable_required_check #:nodoc:
+      @disable_required_check ||= Set.new([:help])
     end
 
     # The method responsible for dispatching given the args.
@@ -393,12 +408,11 @@ class Thor
       @usage ||= nil
       @desc ||= nil
       @long_desc ||= nil
-      @disable_class_options ||= nil
 
       if @usage && @desc
         base_class = @hide ? Thor::HiddenCommand : Thor::Command
-        commands[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options, @disable_class_options)
-        @usage, @desc, @long_desc, @method_options, @hide, @disable_class_options = nil
+        commands[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options)
+        @usage, @desc, @long_desc, @method_options, @hide = nil
         true
       elsif all_commands[meth] || meth == "method_missing"
         true
@@ -480,7 +494,6 @@ class Thor
   map HELP_MAPPINGS => :help
 
   desc "help [COMMAND]", "Describe available commands or one specific command"
-  disable_class_options
   def help(command = nil, subcommand = false)
     if command
       if self.class.subcommands.include? command

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -42,7 +42,7 @@ class Thor
     # config<Hash>:: Configuration for this Thor class.
     #
     def initialize(args = [], local_options = {}, config = {})
-      parse_options = config[:current_command] && config[:current_command].disable_class_options ? {} : self.class.class_options
+      parse_options = self.class.class_options
 
       # The start method splits inbound arguments at the first argument
       # that looks like an option (starts with - or --). It then calls
@@ -65,7 +65,8 @@ class Thor
       # declared options from the array. This will leave us with
       # a list of arguments that weren't declared.
       stop_on_unknown = self.class.stop_on_unknown_option? config[:current_command]
-      opts = Thor::Options.new(parse_options, hash_options, stop_on_unknown)
+      disable_required_check = self.class.disable_required_check? config[:current_command]
+      opts = Thor::Options.new(parse_options, hash_options, stop_on_unknown, disable_required_check)
       self.options = opts.parse(array_options)
       self.options = config[:class_options].merge(options) if config[:class_options]
 
@@ -154,6 +155,12 @@ class Thor
       # regular argument is encountered.  All remaining arguments are passed to
       # the command as regular arguments.
       def stop_on_unknown_option?(command_name) #:nodoc:
+        false
+      end
+
+      # If true, option set will not suspend the execution of the command when
+      # a required option is not provided.
+      def disable_required_check?(command_name) #:nodoc:
         false
       end
 

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -1,9 +1,9 @@
 class Thor
-  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :disable_class_options, :ancestor_name)
+  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :ancestor_name)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
-    def initialize(name, description, long_description, usage, options = nil, disable_class_options = false)
-      super(name.to_s, description, long_description, usage, options || {}, disable_class_options)
+    def initialize(name, description, long_description, usage, options = nil)
+      super(name.to_s, description, long_description, usage, options || {})
     end
 
     def initialize_copy(other) #:nodoc:

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -29,8 +29,9 @@ class Thor
     #
     # If +stop_on_unknown+ is true, #parse will stop as soon as it encounters
     # an unknown option or a regular argument.
-    def initialize(hash_options = {}, defaults = {}, stop_on_unknown = false)
+    def initialize(hash_options = {}, defaults = {}, stop_on_unknown = false, disable_required_check = false)
       @stop_on_unknown = stop_on_unknown
+      @disable_required_check = disable_required_check
       options = hash_options.values
       super(options)
 
@@ -111,7 +112,7 @@ class Thor
         end
       end
 
-      check_requirement!
+      check_requirement! unless @disable_required_check
 
       assigns = Thor::CoreExt::HashWithIndifferentAccess.new(@assigns)
       assigns.freeze


### PR DESCRIPTION
In Thor 0.19.2 it was added a new class method `disable_class_options`.
It was added to disable the check for required options in the help command. This new method disabled the option parser for help, so it is not possible to pass option to that command anymore.

That change introduced a regression and it is fixing the problem at the wrong level. What we want is to disable the required check not the option parsing.

So, we reverted the `disable_class_options` change and added a new method `disable_required_check!` to disable the required check in the commands we want.

Theoretically this is a breaking change but the `disable_class_options` introduction was also a breaking change so it is better to revert it and fix the problem at the correct place.

Related with #462 and #363.

See https://github.com/bundler/bundler/pull/5221