### PR TITLE
Add dash if alias does not have dash

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -94,7 +94,7 @@ class Thor
       if aliases.empty?
         (" " * padding) << sample
       else
-        "#{aliases.join(', ')}, #{sample}"
+        "#{aliases.map{|e|e.to_s.sub(/^(?!\-)/, '-')}.join(', ')}, #{sample}"
       end
     end
 

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -226,8 +226,16 @@ describe Thor::Option do
         expect(parse([:foo, "-f", "-b"], :required).usage).to eq("-f, -b, --foo=FOO")
       end
 
+      it "does not show the usage between brackets(include non-dash-prefixed aliases)" do
+        expect(parse([:foo, "f", "-b"], :required).usage).to eq("-f, -b, --foo=FOO")
+      end
+
       it "does not negate the aliases" do
         expect(parse([:foo, "-f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo]")
+      end
+
+      it "does not negate the aliases(include non-dash-prefixed aliases)" do
+        expect(parse([:foo, "f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo]")
       end
     end
   end


### PR DESCRIPTION
## Sample Code
`alias o` => option `-o`

```ruby
require 'thor'
class SampleCLI < Thor
  desc "command usage", "command desc"
  option "opt", aliases: "o", type: :boolean
  def command(name)
    puts "opt on" if options['opt']
    puts "command #{name}"
  end
end

SampleCLI.start(ARGV)
```

## Actual
Alias help does not have a dash.

```sh
$ ruby sample.rb command hoge
command hoge
$ ruby sample.rb command -o hoge
opt on
command hoge
$ ruby sample.rb command --opt hoge
opt on
command hoge
ruby sample.rb help command
Usage:
  sample.rb command usage

Options:
  o, [--opt], [--no-opt]

command desc
```

## Expected
Alias help has a dash.

```sh
$ ruby sample.rb command hoge
command hoge
$ ruby sample.rb command -o hoge
opt on
command hoge
$ ruby sample.rb command --opt hoge
opt on
command hoge
ruby sample.rb help command
Usage:
  sample.rb command usage

Options:
  -o, [--opt], [--no-opt]

command desc
```

## Related Issue
https://github.com/erikhuda/thor/issues/159