### PR TITLE
Fixes line-wrapping problem with colored output

### DIFF
--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -17,13 +17,22 @@ class Thor
           if complete = completion_proc
             ::Readline.completion_proc = complete
           end
-          ::Readline.readline(prompt, add_to_history?)
+          ::Readline.readline(normalized_prompt, add_to_history?)
         else
           super
         end
       end
 
     private
+
+      def normalized_prompt
+        ansi_colors = @prompt[0..-5].scan(/\e\[[0-9;]*m/)
+                                    .map { |color| "\001" + color + "\002" }
+        return @prompt if ansi_colors.empty?
+
+        @prompt = @prompt.gsub(/\e\[[0-9;]*m/, "")
+        "#{ansi_colors.join}#{prompt}\001\e[0m\002"
+      end
 
       def add_to_history?
         options.fetch(:add_to_history, true)


### PR DESCRIPTION
🌈
Colored output breaks line-wrapping when I press `arrow keys(right and left)` or `Backspace`.
![ruby-readline-bug](https://cloud.githubusercontent.com/assets/5196786/23103153/e9099192-f6be-11e6-97ef-4e94c35838bb.gif)

*Reference: http://stackoverflow.com/a/8916332/1691394*