### PR TITLE
Fix double negatives on bool opts with underscores

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -88,7 +88,7 @@ class Thor
       sample = "[#{sample}]" unless required?
 
       if boolean?
-        sample << ", [#{dasherize('no-' + human_name)}]" unless (name == "force") || name.start_with?("no-")
+        sample << ", [#{dasherize('no-' + human_name)}]" unless (name == "force") || name.start_with?("no-", "no_")
       end
 
       if aliases.empty?

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -201,6 +201,7 @@ describe Thor::Option do
 
     it "does not document a negative option for a negative boolean" do
       expect(parse(:'no-foo', :boolean).usage).not_to include("[--no-no-foo]")
+      expect(parse(:no_foo, :boolean).usage).not_to include("[--no-no-foo]")
     end
 
     it "documents a negative option for a positive boolean starting with 'no'" do


### PR DESCRIPTION
#### Because:

* #460 (released in `0.19.2`) introduced a change that prevents double negative options (`--no-no-foo`) for already negative  boolean options (`--no-foo`).
* That change checks if the option name string starts with 'no-', before it's `dasherized`, therefore negative options defined with underscores (`:no_foo`) still generate a double negative `--no-no-foo` option.

#### This change:

* Adds a test for, and fixes the double negative boolean options
  defined with underscores.