### PR TITLE
update Simplecov dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem "rspec", ">= 3"
   gem "rspec-mocks", ">= 3"
   gem "rubocop", ">= 0.19", :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
-  gem "simplecov", ">= 0.9"
+  gem "simplecov", ">= 0.13"
   gem "term-ansicolor", "~> 1.3.2" # This is to support Ruby 1.8 and 1.9
   gem "tins", "< 1.7" # This is to support Ruby 1.8 and 1.9
   if RUBY_VERSION < "1.9.3"


### PR DESCRIPTION
Simplecov(>= 0.12) has Fixnum waring in Ruby2.4.

I got warning by simplecov-0.12.0. 

```
$ bundle exec rspec spec
/Users/takkanm/src/github.com/erikhuda/thor/spec/helper.rb:31: warning: setting Encoding.default_external
...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1.85 seconds (files took 1.2 seconds to load)
707 examples, 0 failures

/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/configuration.rb:207: warning: constant ::Fixnum is deprecated
/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:29: warning: constant ::Fixnum is deprecated
/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:30: warning: constant ::Fixnum is deprecated
Coverage report generated for RSpec to /Users/takkanm/src/github.com/erikhuda/thor/coverage. 2051 / 2236 LOC (91.73%) covered.
[Coveralls] Outside the CI environment, not sending data.
/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/configuration.rb:207: warning: constant ::Fixnum is deprecated
/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:29: warning: constant ::Fixnum is deprecated
/Users/takkanm/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/simplecov-0.12.0/lib/simplecov/source_file.rb:30: warning: constant ::Fixnum is deprecated
```

So, I update simplecov dependency version.