### PR TITLE
Fix commands running even with pretend enabled

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -251,7 +251,9 @@ class Thor
 
       say_status :run, desc, config.fetch(:verbose, true)
 
-      !options[:pretend] && config[:capture] ? `#{command}` : system(command.to_s)
+      unless options[:pretend]
+        config[:capture] ? `#{command}` : system(command.to_s)
+      end
     end
 
     # Executes a ruby script (taking into account WIN32 platform quirks).

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -253,25 +253,35 @@ describe Thor::Actions do
   end
 
   describe "#run" do
-    before do
-      expect(runner).to receive(:system).with("ls")
+    describe "when not pretending" do
+      before do
+        expect(runner).to receive(:system).with("ls")
+      end
+
+      it "executes the command given" do
+        action :run, "ls"
+      end
+
+      it "logs status" do
+        expect(action(:run, "ls")).to eq("         run  ls from \".\"\n")
+      end
+
+      it "does not log status if required" do
+        expect(action(:run, "ls", :verbose => false)).to be_empty
+      end
+
+      it "accepts a color as status" do
+        expect(runner.shell).to receive(:say_status).with(:run, 'ls from "."', :yellow)
+        action :run, "ls", :verbose => :yellow
+      end
     end
 
-    it "executes the command given" do
-      action :run, "ls"
-    end
-
-    it "logs status" do
-      expect(action(:run, "ls")).to eq("         run  ls from \".\"\n")
-    end
-
-    it "does not log status if required" do
-      expect(action(:run, "ls", :verbose => false)).to be_empty
-    end
-
-    it "accepts a color as status" do
-      expect(runner.shell).to receive(:say_status).with(:run, 'ls from "."', :yellow)
-      action :run, "ls", :verbose => :yellow
+    describe "when pretending" do
+      it "doesn't execute the command" do
+        runner = MyCounter.new([1], %w(--pretend))
+        expect(runner).not_to receive(:system)
+        runner.run("ls", :verbose => false)
+      end
     end
   end
 


### PR DESCRIPTION
🌈 

This PR fixes a bug that I believe was introduced in 9dde9502be1730d59eafe2a2e8b3361cb11e3bb7 in `Thor::Actions#run`.

This is the current code:
```ruby
!options[:pretend] && config[:capture] ? `#{command}` : system(command.to_s)`.
```
As you can see, even if `options[:pretend]` is true, the command will be run.

I've reverted the change and added a test case.