### PR TITLE
Updating rake and rdoc to recent versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "rake", "< 11"
-gem "rdoc", "~> 4.2.2" # This is to support Ruby 1.8 and 1.9
+gem "rake", "~> 12.0.0"
+gem "rdoc", "~> 5.1.0" # This is to support Ruby 1.8 and 1.9
 
 group :development do
   gem "pry"


### PR DESCRIPTION
Gemnasium shows that runtime dependencies needed updates for both rake and rdoc,
updated to the latest versions, tests are green, I hope I'm not missing anything.