### PR TITLE
Prevent infinite loop on file collision when stdin closed

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -252,6 +252,9 @@ class Thor
           )
 
           case answer
+          when nil
+            say ""
+            return true
           when is?(:yes), is?(:force), ""
             return true
           when is?(:no), is?(:skip)

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -310,6 +310,12 @@ TABLE
       shell.file_collision("foo")
     end
 
+    it "outputs a new line and returns true if stdin is closed" do
+      expect($stdout).to receive(:print).with("\n")
+      expect(Thor::LineEditor).to receive(:readline).and_return(nil)
+      expect(shell.file_collision("foo")).to be true
+    end
+
     it "returns true if the user chooses default option" do
       expect(Thor::LineEditor).to receive(:readline).and_return("")
       expect(shell.file_collision("foo")).to be true


### PR DESCRIPTION
🌈

If stdin is closed, any attempt to read user input returns `nil`, resulting in an infinite loop on file collision since that case isn't accounted for. The solution I have submitted treats `nil` the same as pressing enter. I'm also outputting a newline to prevent subsequent output from ending up on the same line.