### PR TITLE
Updates so things work with frozen string literals

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -140,7 +140,7 @@ class Thor
         end
       end
 
-      message = "Could not find #{file.inspect} in any of your source paths. "
+      message = "Could not find #{file.inspect} in any of your source paths. ".dup
 
       unless self.class.source_root
         message << "Please invoke #{self.class.name}.source_root(PATH) with the PATH containing your templates. "

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -341,7 +341,7 @@ class Thor
     end
 
     def with_output_buffer(buf = "".dup) #:nodoc:
-      raise "No: #{buf}" if buf.frozen?
+      raise ArgumentError, "Buffer can not be a frozen object" if buf.frozen?
       old_buffer = output_buffer
       self.output_buffer = buf
       yield

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -340,7 +340,8 @@ class Thor
       with_output_buffer { yield(*args) }
     end
 
-    def with_output_buffer(buf = "") #:nodoc:
+    def with_output_buffer(buf = "".dup) #:nodoc:
+      raise "No: #{buf}" if buf.frozen?
       old_buffer = output_buffer
       self.output_buffer = buf
       yield
@@ -355,7 +356,7 @@ class Thor
       def set_eoutvar(compiler, eoutvar = "_erbout")
         compiler.put_cmd = "#{eoutvar}.concat"
         compiler.insert_cmd = "#{eoutvar}.concat"
-        compiler.pre_cmd = ["#{eoutvar} = ''"]
+        compiler.pre_cmd = ["#{eoutvar} = ''.dup"]
         compiler.post_cmd = [eoutvar]
       end
     end

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -485,7 +485,7 @@ class Thor
 
       def handle_argument_error(command, error, args, arity) #:nodoc:
         name = [command.ancestor_name, command.name].compact.join(" ")
-        msg = "ERROR: \"#{basename} #{name}\" was called with "
+        msg = "ERROR: \"#{basename} #{name}\" was called with ".dup
         msg << "no arguments"               if     args.empty?
         msg << "arguments " << args.inspect unless args.empty?
         msg << "\nUsage: #{banner(command).inspect}"

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -40,14 +40,14 @@ class Thor
     # and required options into the given usage.
     def formatted_usage(klass, namespace = true, subcommand = false)
       if ancestor_name
-        formatted = "#{ancestor_name} " # add space
+        formatted = "#{ancestor_name} ".dup # add space
       elsif namespace
         namespace = klass.namespace
-        formatted = "#{namespace.gsub(/^(default)/, '')}:"
+        formatted = "#{namespace.gsub(/^(default)/, '')}:".dup
       end
-      formatted ||= "#{klass.namespace.split(':').last} " if subcommand
+      formatted ||= "#{klass.namespace.split(':').last} ".dup if subcommand
 
-      formatted ||= ""
+      formatted ||= "".dup
 
       # Add usage with required arguments
       formatted << if klass && !klass.arguments.empty?

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -205,7 +205,7 @@ class Thor::Group
     alias_method :printable_tasks, :printable_commands
 
     def handle_argument_error(command, error, _args, arity) #:nodoc:
-      msg = "#{basename} #{command.name} takes #{arity} argument"
+      msg = "#{basename} #{command.name} takes #{arity} argument".dup
       msg << "s" if arity > 1
       msg << ", but it should not."
       raise error, msg

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -80,12 +80,12 @@ class Thor
 
     def usage(padding = 0)
       sample = if banner && !banner.to_s.empty?
-        "#{switch_name}=#{banner}"
+        "#{switch_name}=#{banner}".dup
       else
         switch_name
       end
 
-      sample = "[#{sample}]" unless required?
+      sample = "[#{sample}]".dup unless required?
 
       if boolean?
         sample << ", [#{dasherize('no-' + human_name)}]" unless (name == "force") || name.start_with?("no-")

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -107,7 +107,7 @@ class Thor
         status = set_color status, color, true if color
 
         buffer = "#{status}#{spaces}#{message}"
-        buffer << "\n" unless buffer.end_with?("\n")
+        buffer = "#{buffer}\n" unless buffer.end_with?("\n")
 
         stdout.print(buffer)
         stdout.flush
@@ -162,7 +162,7 @@ class Thor
         colwidth = options[:colwidth]
         options[:truncate] = terminal_width if options[:truncate] == true
 
-        formats << "%-#{colwidth + 2}s" if colwidth
+        formats << "%-#{colwidth + 2}s".dup if colwidth
         start = colwidth ? 1 : 0
 
         colcount = array.max { |a, b| a.size <=> b.size }.size
@@ -174,9 +174,9 @@ class Thor
           maximas << maxima
           formats << if index == colcount - 1
                        # Don't output 2 trailing spaces when printing the last column
-                       "%-s"
+                       "%-s".dup
                      else
-                       "%-#{maxima + 2}s"
+                       "%-#{maxima + 2}s".dup
                      end
         end
 
@@ -184,7 +184,7 @@ class Thor
         formats << "%s"
 
         array.each do |row|
-          sentence = ""
+          sentence = "".dup
 
           row.each_with_index do |column, index|
             maxima = maximas[index]
@@ -409,7 +409,7 @@ class Thor
 
         return unless result
 
-        result.strip!
+        result = result.strip
 
         if default && result == ""
           default

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -204,7 +204,7 @@ describe Thor::Actions do
 
   describe "#apply" do
     before do
-      @template = <<-TEMPLATE
+      @template = <<-TEMPLATE.dup
         @foo = "FOO"
         say_status :cool, :padding
       TEMPLATE

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -190,7 +190,7 @@ describe Thor::Group do
         class_option :loud, :type => :boolean
 
         def hi
-          name.upcase! if options[:loud]
+          self.name = name.upcase if options[:loud]
           "Hi #{name}"
         end
       end
@@ -207,7 +207,7 @@ describe Thor::Group do
         class_option :loud, :type => :boolean
 
         def hi
-          name.upcase! if options[:loud]
+          self.name = name.upcase if options[:loud]
           out = "Hi #{name}"
           out << ": " << args.join(", ") unless args.empty?
           out

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -531,7 +531,7 @@ HELP
         method_option :loud, :type => :boolean
         desc "hi NAME", "say hi to name"
         def hi(name)
-          name.upcase! if options[:loud]
+          name = name.upcase if options[:loud]
           "Hi #{name}"
         end
       end


### PR DESCRIPTION
These changes get Thor working when frozen string literals are enabled.

Regarding test suite dependencies and their compatibility with frozen string literals:

* RSpec is compatible in their latest git commits (for `rspec-core`, `rspec-expectations`, etc).
* `simplecov` and its dependency `simplecov-html` are compatible in their latest git commits.
* Addressable is compatible in this PR: https://github.com/sporkmonger/addressable/pull/260
* Webmock is not yet compatible - I'm working on it, though I've also uncovered a frozen string literal bug in stdlib. The patches I've made locally (not yet submitted to a PR) are enough to get Thor's build green though.