### PR TITLE
Add `check_default_type!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.20.0
+* Add `check_default_type!` to check if the default value of an option matches the defined type.
+  It removes the warning on usage and gives the command authors the possibility to check for programming errors.
+
 * Add `disable_required_check!` to disable check for required options in some commands.
   It is a substitute of `disable_class_options` that was not working as intended.
 

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -151,6 +151,21 @@ class Thor
         !!check_unknown_options
       end
 
+      # If you want to raise an error when the default value of an option does not match
+      # the type call check_default_type!
+      # This is disabled by default for compatibility.
+      def check_default_type!
+        @check_default_type = true
+      end
+
+      def check_default_type #:nodoc:
+        @check_default_type ||= from_superclass(:check_default_type, false)
+      end
+
+      def check_default_type? #:nodoc:
+        !!check_default_type
+      end
+
       # If true, option parsing is suspended as soon as an unknown option or a
       # regular argument is encountered.  All remaining arguments are passed to
       # the command as regular arguments.
@@ -549,7 +564,7 @@ class Thor
       # options<Hash>:: Described in both class_option and method_option.
       # scope<Hash>:: Options hash that is being built up
       def build_option(name, options, scope) #:nodoc:
-        scope[name] = Thor::Option.new(name, options)
+        scope[name] = Thor::Option.new(name, options.merge(:check_default_type => check_default_type?))
       end
 
       # Receives a hash of options, parse them and add to the scope. This is a

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -5,6 +5,7 @@ class Thor
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
     def initialize(name, options = {})
+      @check_default_type = options[:check_default_type]
       options[:required] = false unless options.key?(:required)
       super
       @lazy_default = options[:lazy_default]
@@ -110,7 +111,7 @@ class Thor
 
     def validate!
       raise ArgumentError, "An option cannot be boolean and required." if boolean? && required?
-      validate_default_type!
+      validate_default_type! if @check_default_type
     end
 
     def validate_default_type!
@@ -127,8 +128,7 @@ class Thor
         @default.class.name.downcase.to_sym
       end
 
-      # TODO: This should raise an ArgumentError in a future version of Thor
-      warn "WARNING: Expected #{@type} default value for '#{switch_name}'; got #{@default.inspect} (#{default_type})" unless default_type == @type
+      raise ArgumentError, "Expected #{@type} default value for '#{switch_name}'; got #{@default.inspect} (#{default_type})" unless default_type == @type
     end
 
     def dasherized?

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -8,7 +8,7 @@ if RUBY_VERSION >= "1.9"
 
   SimpleCov.start do
     add_filter "/spec"
-    minimum_coverage(91.69)
+    minimum_coverage(90)
   end
 end
 

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -134,15 +134,21 @@ describe Thor::Option do
     expect(option).to be_required
   end
 
-  it "raises an error if default is inconsistent with type" do
-    expect(capture(:stderr) do
-      option("foo_bar", :type => :numeric, :default => "baz")
-    end.chomp).to eq('WARNING: Expected numeric default value for \'--foo-bar\'; got "baz" (string)')
+  it "raises an error if default is inconsistent with type and check_default_type is true" do
+    expect do
+      option("foo_bar", :type => :numeric, :default => "baz", :check_default_type => true)
+    end.to raise_error(ArgumentError, 'Expected numeric default value for \'--foo-bar\'; got "baz" (string)')
   end
 
-  it "does not raises an error if default is an symbol and type string" do
+  it "does not raises an error if default is an symbol and type string and check_default_type is true" do
     expect do
-      option("foo", :type => :string, :default => :bar)
+      option("foo", :type => :string, :default => :bar, :check_default_type => true)
+    end.not_to raise_error
+  end
+
+  it "does not raises an error if default is inconsistent with type and check_default_type is false" do
+    expect do
+      option("foo_bar", :type => :numeric, :default => "baz", :check_default_type => false)
     end.not_to raise_error
   end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -583,6 +583,24 @@ HELP
       expect(klass.start(%w(unknown foo --bar baz))).to eq(%w(foo))
     end
 
+    it "does not check the default type when check_default_type! is not called" do
+      expect do
+        Class.new(Thor) do
+          option "bar", :type => :numeric, :default => "foo"
+        end
+      end.not_to raise_error
+    end
+
+    it "checks the default type when check_default_type! is called" do
+      expect do
+        Class.new(Thor) do
+          check_default_type!
+
+          option "bar", :type => :numeric, :default => "foo"
+        end
+      end.to raise_error(ArgumentError, "Expected numeric default value for '--bar'; got \"foo\" (string)")
+    end
+
     it "send as a command name" do
       expect(MyScript.start(%w(send))).to eq(true)
     end


### PR DESCRIPTION
It check if the default value of an option matches the defined type.

This removes the warning on usage since there is no much what the command users could do about it and give the command authors the possibility to check for programming errors.