### PR TITLE
Fix bug and refactoring

### DIFF
--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -53,10 +53,12 @@ class Thor
           replacement + '\0'
         end
 
-        if File.exist?(destination)
+        if exists?
           replace!(/#{flag}/, content, config[:force])
         else
-          raise Thor::Error, "The file #{ destination } does not appear to exist"
+          unless pretend?
+            raise Thor::Error, "The file #{ destination } does not appear to exist"
+          end
         end
       end
 
@@ -95,7 +97,7 @@ class Thor
       # Adds the content to the file.
       #
       def replace!(regexp, string, force)
-        return if base.options[:pretend]
+        return if pretend?
         content = File.read(destination)
         if force || !content.include?(replacement)
           content.gsub!(regexp, string)

--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -73,10 +73,20 @@ describe Thor::Actions::InjectIntoFile do
 
     it "does not attempt to change the file if it doesn't exist - instead raises Thor::Error" do
       expect do
-	invoke! "idontexist", :before => "something" do
-	  "any content"
-	end
+        invoke! "idontexist", :before => "something" do
+          "any content"
+        end
       end.to raise_error(Thor::Error, /does not appear to exist/)
+      expect(File.exist?("idontexist")).to be_falsey
+    end
+
+    it "does not attempt to change the file if it doesn't exist and pretending" do
+      expect do
+        invoker :pretend => true
+        invoke! "idontexist", :before => "something" do
+          "any content"
+        end
+      end.not_to raise_error
       expect(File.exist?("idontexist")).to be_falsey
     end
 


### PR DESCRIPTION
When a file does not exists and sets `options[:pretend]`, it cause raise `Thor::Error`. So I've fixed it with minor refactoring.
