### PR TITLE
require open-uri when loading http template

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -217,6 +217,7 @@ class Thor
       shell.padding += 1 if verbose
 
       contents = if is_uri
+        require "open-uri"
         open(path, "Accept" => "application/x-thor-template", &:read)
       else
         open(path, &:read)


### PR DESCRIPTION
🌈


v0.20.0 [no longer requires OpenURI from `actions/file_manipulation.rb`](https://github.com/erikhuda/thor/compare/v0.19.4...v0.20.0#diff-a84da9a4ac4630ff251b04465cac2159L2).  This file is required by `actions.rb`. Since OpenURL is no longer loaded  a `no implicit conversion of Hash into String` error occurs when `Thor::Actions#apply` tries to load a file via HTTP(S) because `open` has not been modified [to accept HTTP headers](https://github.com/erikhuda/thor/blob/d55d8ad81f1739ed86c0a110af29d1582e51b7e4/lib/thor/actions.rb#L220):

```
/tmp/test-app-pad >padrino gen plugin coffee
       apply  https://raw.github.com/padrino/padrino-recipes/master/plugins/coffee_plugin.rb
  The template at https://raw.github.com/padrino/padrino-recipes/master/plugins/coffee_plugin.rb could not be found: no implicit conversion of Hash into String  
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/actions.rb:220:in `initialize'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/actions.rb:220:in `open'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/actions.rb:220:in `apply'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/padrino-gen-0.13.3.3/lib/padrino-gen/generators/runner.rb:135:in `execute_runner'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/padrino-gen-0.13.3.3/lib/padrino-gen/generators/plugin.rb:42:in `setup_plugin'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `block in invoke_all'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `each'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `map'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `invoke_all'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/group.rb:232:in `dispatch'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/padrino-gen-0.13.3.3/lib/padrino-gen/generators/cli.rb:50:in `setup'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `block in invoke_all'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `each'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `map'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `invoke_all'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/group.rb:232:in `dispatch'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
/Users/sshaw/.rvm/gems/ruby-2.3.0/gems/padrino-gen-0.13.3.3/bin/padrino-gen:16:in `<main>'
```

My commit loads it when needed, which [seems to be the preferred style](https://github.com/erikhuda/thor/compare/v0.19.4...v0.20.0#diff-f8ad773f327e75ac0dae88f03b0098d1). But, due to [how things are stubbed](https://github.com/erikhuda/thor/blob/d55d8ad81f1739ed86c0a110af29d1582e51b7e4/spec/actions_spec.rb#L219), this error was not detected by the test. I considered `and_call_original` but since `OpenURI` is lazy loaded, the `original` implementation is called not the HTTP one. 


