### PR TITLE
Fix incorrect use of Process::exit. This fixes open issue #244.

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -466,13 +466,13 @@ class Thor
         dispatch(nil, given_args.dup, nil, config)
       rescue Thor::Error => e
         config[:debug] || ENV["THOR_DEBUG"] == "1" ? (raise e) : config[:shell].error(e.message)
-        exit(1) if exit_on_failure?
+        exit(false) if exit_on_failure?
       rescue Errno::EPIPE
         # This happens if a thor command is piped to something like `head`,
         # which closes the pipe when it's done reading. This will also
         # mean that if the pipe is closed, further unnecessary
         # computation will not occur.
-        exit(0)
+        exit(true)
       end
 
       # Allows to use private methods from parent in child classes as commands.

--- a/spec/fixtures/exit_status.thor
+++ b/spec/fixtures/exit_status.thor
@@ -1,0 +1,19 @@
+require "thor"
+
+class ExitStatus < Thor
+  def self.exit_on_failure?
+    true
+  end
+
+  desc "error", "exit with a planned error"
+  def error
+    raise Thor::Error.new("planned error")
+  end
+
+  desc "ok", "exit with no error"
+  def ok
+  end
+end
+
+ExitStatus.start(ARGV)
+

--- a/spec/script_exit_status_spec.rb
+++ b/spec/script_exit_status_spec.rb
@@ -1,0 +1,29 @@
+describe "when the Thor class's exit_with_failure? method returns true" do
+  def thor_command(command)
+    gem_dir= File.expand_path("#{File.dirname(__FILE__)}/..")
+    lib_path= "#{gem_dir}/lib"
+    script_path= "#{gem_dir}/spec/fixtures/exit_status.thor"
+    ruby_lib= ENV['RUBYLIB'].nil? ? lib_path : "#{lib_path}:#{ENV['RUBYLIB']}"
+
+    full_command= "ruby #{script_path} #{command}"
+    r,w= IO.pipe
+    pid= spawn({'RUBYLIB' => ruby_lib},
+               full_command,
+               {:out => w, :err => [:child, :out]})
+    w.close
+
+    junk, exit_status= Process.wait2(pid)
+    junk= r.read
+    r.close
+
+    exit_status.exitstatus
+  end
+
+  it "a command that raises a Thor::Error exits with a status of 1" do
+    expect(thor_command("error")).to eq(1)
+  end
+
+  it "a command that does not raise a Thor::Error exits with a status of 0" do
+    expect(thor_command("ok")).to eq(0)
+  end
+end


### PR DESCRIPTION
🌈
Unlike the C library function exit(), Ruby's version takes a boolean,
not an integer. Added a spec to check the actual shell-level exit
value of a Thor script, and fixed calls to Process::exit.