### PR TITLE
Remove the root path from the absolute path only once

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -114,7 +114,7 @@ class Thor
     #
     def relative_to_original_destination_root(path, remove_dot = true)
       path = path.dup
-      if path.gsub!(@destination_stack[0], ".")
+      if path.sub!(@destination_stack[0], ".")
         remove_dot ? (path[2..-1] || "") : path
       else
         path

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -86,6 +86,11 @@ describe Thor::Actions do
         expect(runner.relative_to_original_destination_root("/test/file")).to eq("/test/file")
       end
 
+      it "removes the root path from the absolute path only once" do
+        runner.destination_root = "/app"
+        expect(runner.relative_to_original_destination_root("/app/project/application")).to eq("project/application")
+      end
+
       it "does not fail with files containing regexp characters" do
         runner = MyCounter.new([1], {}, :destination_root => File.join(destination_root, "fo[o-b]ar"))
         expect(runner.relative_to_original_destination_root("bar")).to eq("bar")


### PR DESCRIPTION
🌈In cases where root path is also a substring of a relative path, it was being erroneously removed twice (or more).

e.g. for absolute path `/app/config/application.rb` when root is `/app` it would display the relative path as `config.lication.rb` instead of `config/application.rb`.