### PR TITLE
Use correct line numbers for `class_eval` and `module_eval` methods

### DIFF
--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -61,7 +61,7 @@ class Thor::Group
         invocations[name] = false
         invocation_blocks[name] = block if block_given?
 
-        class_eval <<-METHOD, __FILE__, __LINE__
+        class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def _invoke_#{name.to_s.gsub(/\W/, '_')}
             klass, command = self.class.prepare_for_invocation(nil, #{name.inspect})
 
@@ -120,7 +120,7 @@ class Thor::Group
         invocations[name] = true
         invocation_blocks[name] = block if block_given?
 
-        class_eval <<-METHOD, __FILE__, __LINE__
+        class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def _invoke_from_option_#{name.to_s.gsub(/\W/, '_')}
             return unless options[#{name.inspect}]
 

--- a/lib/thor/shell.rb
+++ b/lib/thor/shell.rb
@@ -55,7 +55,7 @@ class Thor
 
     # Common methods that are delegated to the shell.
     SHELL_DELEGATED_METHODS.each do |method|
-      module_eval <<-METHOD, __FILE__, __LINE__
+      module_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{method}(*args,&block)
           shell.#{method}(*args,&block)
         end


### PR DESCRIPTION
🌈 When using heredoc, the line number that is passed to `eval` method should be a `__LINE__ + 1`.

For example

```ruby
instance_eval <<-END, __FILE__, __LINE__
  raise 'In the instance_eval'
END
```

It print below.

```bash
$ ruby test.rb
test.rb:1:in `<main>': In the instance_eval (RuntimeError)
	from test.rb:1:in `instance_eval'
	from test.rb:1:in `<main>'
```

It says "This exception occurred on the 1st line", but the `raise` is on the 2nd line.

This change will fix this problem.