### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -117,7 +117,13 @@ class Thor
       context = config.delete(:context) || instance_eval("binding")
 
       create_file destination, nil, config do
-        content = CapturableERB.new(::File.binread(source), nil, "-", "@output_buffer").tap do |erb|
+        match = ERB.version.match(/(\d\.\d\.\d)/)
+        capturable_erb = if match && match[1] >= "2.2.0" # Ruby 2.6+
+          CapturableERB.new(::File.binread(source), :trim_mode => "-", :eoutvar => "@output_buffer")
+        else
+          CapturableERB.new(::File.binread(source), nil, "-", "@output_buffer")
+        end
+        content = capturable_erb.tap do |erb|
           erb.filename = source
         end.result(context)
         content = yield(content) if block


### PR DESCRIPTION
The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

The following address is related Ruby's commit.
https://github.com/ruby/ruby/commit/cc777d0

This PR uses `ERB.version` to switch `ERB.new` interface. Because Thor supports multiple Ruby versions, it need to use the appropriate interface.

Using `ERB.version` instead of `RUBY_VERSON` is based on the following patch.
https://github.com/ruby/ruby/pull/1826

This patch is built into Ruby.
https://github.com/ruby/ruby/commit/40db89c0934c23d7464d47946bb682b9035411f9