### PR TITLE
Accumulate values from multiple switch instances with :hash or :array types

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -39,6 +39,8 @@ class Thor
 
     def parse(args)
       @pile = args.dup
+      @hashes = Hash.new { |h, k| h[k] = {} }
+      @arrays = Hash.new { |h, k| h[k] = [] }
 
       @switches.each do |argument|
         break unless peek
@@ -96,13 +98,14 @@ class Thor
     #
     def parse_hash(name)
       return shift if peek.is_a?(Hash)
-      hash = {}
+      hash = @hashes[name]
 
       while current_is_value? && peek.include?(":")
         key, value = shift.split(":", 2)
         raise MalformattedArgumentError, "You can't specify '#{key}' more than once in option '#{name}'; got #{key}:#{hash[key]} and #{key}:#{value}" if hash.include? key
         hash[key] = value
       end
+
       hash
     end
 
@@ -117,7 +120,7 @@ class Thor
     #
     def parse_array(name)
       return shift if peek.is_a?(Array)
-      array = []
+      array = @arrays[name]
       array << shift while current_is_value?
       array
     end

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -75,6 +75,8 @@ class Thor
     def parse(args) # rubocop:disable MethodLength
       @pile = args.dup
       @parsing_options = true
+      @hashes = Hash.new { |h, k| h[k] = {} }
+      @arrays = Hash.new { |h, k| h[k] = [] }
 
       while peek
         if parsing_options?

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -383,6 +383,10 @@ describe Thor::Options do
       it "must not allow the same hash key to be specified multiple times" do
         expect { parse("--attributes", "name:string", "name:integer") }.to raise_error(Thor::MalformattedArgumentError, "You can't specify 'name' more than once in option '--attributes'; got name:string and name:integer")
       end
+
+      it "accumulates values from multiple switch instances" do
+        expect(parse("--attributes=name:string", "--attributes", "age:integer")["attributes"]).to eq("name" => "string", "age" => "integer")
+      end
     end
 
     describe "with :array type" do
@@ -400,6 +404,10 @@ describe Thor::Options do
 
       it "must not mix values with other switches" do
         expect(parse("--attributes", "a", "b", "c", "--baz", "cool")["attributes"]).to eq(%w(a b c))
+      end
+
+      it "accumulates values from multiple switch instances" do
+        expect(parse("--attributes=a", "b", "--attributes", "c")["attributes"]).to eq(%w(a b c))
       end
     end
 


### PR DESCRIPTION
🌈

Allows multi-valued options (Hash or Array) to be specified multiple times, and all the values are accumulated. To illustrate, suppose you configured a Hash option, e.g.
```
option :env, :type => :hash
```
Prior to this change, you'd pass a single `--env` switch to your executable, e.g.
```
$ my-thing --env FOO:foo BAR:bar
# options => { "env" => { "FOO" => "foo", "BAR" => "bar" } }
```
If you tried to use multiple instances of the `--env` switch, only the last one would take effect:
```
$ my-thing --env FOO:foo --env BAR:bar
# options => { "env" => { "BAR" => "bar" } }
```
After this change, you can still use a single `--env` switch with multiple values:
```
$ my-thing --env FOO:foo BAR:bar
# options => { "env" => { "FOO" => "foo", "BAR" => "bar" } }
```
But now, using multiple `--env` switches will also work as one might expect:
```
$ my-thing --env FOO:foo --env BAR:bar
# options => { "env" => { "FOO" => "foo", "BAR" => "bar" } }
```