### PR TITLE
Address #595 by duplicating string objects

### DIFF
--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -139,7 +139,7 @@ describe Thor::Actions do
 
     it "accepts http remote sources" do
       body = "__start__\nHTTPFILE\n__end__\n"
-      stub_request(:get, "http://example.com/file.txt").to_return(:body => body)
+      stub_request(:get, "http://example.com/file.txt").to_return(:body => body.dup)
       action :get, "http://example.com/file.txt" do |content|
         expect(a_request(:get, "http://example.com/file.txt")).to have_been_made
         expect(content).to eq(body)
@@ -148,7 +148,7 @@ describe Thor::Actions do
 
     it "accepts https remote sources" do
       body = "__start__\nHTTPSFILE\n__end__\n"
-      stub_request(:get, "https://example.com/file.txt").to_return(:body => body)
+      stub_request(:get, "https://example.com/file.txt").to_return(:body => body.dup)
       action :get, "https://example.com/file.txt" do |content|
         expect(a_request(:get, "https://example.com/file.txt")).to have_been_made
         expect(content).to eq(body)


### PR DESCRIPTION
This pull request addresses these failures reported #595 by duplicating string objects.

```ruby
$ ruby -v
ruby 2.6.0dev (2018-04-13 trunk 63143) [x86_64-linux]
$ bundle exec rspec ./spec/actions/file_manipulation_spec.rb
.. snip ..
................................

Failures:

  1) Thor::Actions#get accepts http remote sources
     Failure/Error: expect(content).to eq(body)

       expected: ""
            got: "__start__\nHTTPFILE\n__end__\n"

       (compared using ==)

       Diff:
       @@ -1 +1,4 @@
       +__start__
       +HTTPFILE
       +__end__

     # ./spec/actions/file_manipulation_spec.rb:145:in `block (4 levels) in <top (required)>'
     # ./lib/thor/actions/file_manipulation.rb:89:in `get'
     # ./spec/actions/file_manipulation_spec.rb:12:in `block in action'
     # ./spec/helper.rb:55:in `capture'
     # ./spec/actions/file_manipulation_spec.rb:12:in `action'
     # ./spec/actions/file_manipulation_spec.rb:143:in `block (3 levels) in <top (required)>'

  2) Thor::Actions#get accepts https remote sources
     Failure/Error: expect(content).to eq(body)

       expected: ""
            got: "__start__\nHTTPSFILE\n__end__\n"

       (compared using ==)

       Diff:
       @@ -1 +1,4 @@
       +__start__
       +HTTPSFILE
       +__end__

     # ./spec/actions/file_manipulation_spec.rb:154:in `block (4 levels) in <top (required)>'
     # ./lib/thor/actions/file_manipulation.rb:89:in `get'
     # ./spec/actions/file_manipulation_spec.rb:12:in `block in action'
     # ./spec/helper.rb:55:in `capture'
     # ./spec/actions/file_manipulation_spec.rb:12:in `action'
     # ./spec/actions/file_manipulation_spec.rb:152:in `block (3 levels) in <top (required)>'

Finished in 0.11101 seconds (files took 0.35057 seconds to load)
62 examples, 2 failures

Failed examples:

rspec ./spec/actions/file_manipulation_spec.rb:140 # Thor::Actions#get accepts http remote sources
rspec ./spec/actions/file_manipulation_spec.rb:149 # Thor::Actions#get accepts https remote sources

Coverage report generated for RSpec to /home/yahonda/git/thor/coverage. 1059 / 1948 LOC (54.36%) covered.
[Coveralls] Outside the CI environment, not sending data.
$
```

Actually, I do not know if there is something wrong with `thor` or `webmock` which provides `stub_request` method but wanted to provide a way to fix. Thanks @koic who suggested this fix.