### PR TITLE
Make sure future versions of ERB are invoked appropriately

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -117,7 +117,7 @@ class Thor
       context = config.delete(:context) || instance_eval("binding")
 
       create_file destination, nil, config do
-        match = ERB.version.match(/(\d\.\d\.\d)/)
+        match = ERB.version.match(/(\d+\.\d+\.\d+)/)
         capturable_erb = if match && match[1] >= "2.2.0" # Ruby 2.6+
           CapturableERB.new(::File.binread(source), :trim_mode => "-", :eoutvar => "@output_buffer")
         else


### PR DESCRIPTION
Fix introduced in #594 misidentifies versions with more numerics.
As shown by @ahorek , version "2.11.0", for example, would be called using the deprecated API.

Long live ERB.