### PR TITLE
Fix comment_lines regexp

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -307,7 +307,7 @@ class Thor
     def comment_lines(path, flag, *args)
       flag = flag.respond_to?(:source) ? flag.source : flag
 
-      gsub_file(path, /^(\s*)([^#|\n]*#{flag})/, '\1# \2', *args)
+      gsub_file(path, /^(\s*)([^#\n]*#{flag})/, '\1# \2', *args)
     end
 
     # Removes a file at the given location.


### PR DESCRIPTION
🌈 

The previous regexp was likely a typo, and it prevented lines which begin with a pipe ("|") from being commented out.