### PR TITLE
Add `merge` action to file colision menu

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -247,11 +247,11 @@ class Thor
       #
       # ==== Parameters
       # destination<String>:: the destination file to solve conflicts
-      # block<Proc>:: an optional block that returns the value to be used in diff
+      # block<Proc>:: an optional block that returns the value to be used in diff and merge
       #
       def file_collision(destination)
         return true if @always_force
-        options = block_given? ? "[Ynaqdh]" : "[Ynaqh]"
+        options = block_given? ? "[Ynaqdhm]" : "[Ynaqh]"
 
         loop do
           answer = ask(
@@ -275,6 +275,13 @@ class Thor
           when is?(:diff)
             show_diff(destination, yield) if block_given?
             say "Retrying..."
+          when is?(:merge)
+            if block_given? && !merge_tool.empty?
+              merge(destination, yield)
+              return nil
+            end
+
+            say "Please specify merge tool to `THOR_MERGE` env."
           else
             say file_collision_help
           end
@@ -352,6 +359,7 @@ class Thor
         q - quit, abort
         d - diff, show the differences between the old and the new
         h - help, show this help
+        m - merge, run merge tool
         HELP
       end
 
@@ -439,6 +447,23 @@ class Thor
           say("Your response must be one of: [#{answers}]. Please try again.") unless correct_answer
         end
         correct_answer
+      end
+
+      def merge(destination, content) #:nodoc:
+        require "tempfile"
+        Tempfile.open([File.basename(destination), File.extname(destination)], File.dirname(destination)) do |temp|
+          temp.write content
+          temp.rewind
+          system %(#{merge_tool} "#{temp.path}" "#{destination}")
+        end
+      end
+
+      def merge_tool #:nodoc:
+        @merge_tool ||= ENV["THOR_MERGE"] || git_merge_tool
+      end
+
+      def git_merge_tool #:nodoc:
+        `git config merge.tool`.rstrip rescue ""
       end
     end
   end

--- a/spec/actions/create_file_spec.rb
+++ b/spec/actions/create_file_spec.rb
@@ -104,7 +104,7 @@ describe Thor::Actions::CreateFile do
         it "shows conflict status to the user" do
           file = File.join(destination_root, "doc/config.rb")
           expect(create_file("doc/config.rb")).not_to be_identical
-          expect(Thor::LineEditor).to receive(:readline).with("Overwrite #{file}? (enter \"h\" for help) [Ynaqdh] ", anything).and_return("s")
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite #{file}? (enter \"h\" for help) [Ynaqdhm] ", anything).and_return("s")
 
           content = invoke!
           expect(content).to match(%r{conflict  doc/config\.rb})
@@ -127,6 +127,14 @@ describe Thor::Actions::CreateFile do
           create_file("doc/config.rb")
           expect(Thor::LineEditor).to receive(:readline).and_return("d", "n")
           expect(@base.shell).to receive(:system).with(/diff -u/)
+          invoke!
+        end
+
+        it "executes the block given to run merge tool" do
+          create_file("doc/config.rb")
+          allow(@base.shell).to receive(:merge_tool).and_return("meld")
+          expect(Thor::LineEditor).to receive(:readline).and_return("m")
+          expect(@base.shell).to receive(:system).with(/meld/)
           invoke!
         end
       end


### PR DESCRIPTION
Currently, if want to reflect the changed contents, only have to grasp the contents of diff and reflect it manually later or overwrite once to check the difference. This is a little inconvenient.

If merge is selected, the specified merge tool will be executed. By doing this, can reflect changes while checking.

The merge tool is obtained from environment variables and git config.
I doubt that it is appropriate to get a value from git config, but I am thinking that there may be useful.