### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@ Thor
 
 [![Gem Version](http://img.shields.io/gem/v/thor.svg)][gem]
 [![Build Status](http://img.shields.io/travis/erikhuda/thor.svg)][travis]
-[![Dependency Status](http://img.shields.io/gemnasium/erikhuda/thor.svg)][gemnasium]
 [![Code Climate](http://img.shields.io/codeclimate/github/erikhuda/thor.svg)][codeclimate]
 [![Coverage Status](http://img.shields.io/coveralls/erikhuda/thor.svg)][coveralls]
 
 [gem]: https://rubygems.org/gems/thor
 [travis]: http://travis-ci.org/erikhuda/thor
-[gemnasium]: https://gemnasium.com/erikhuda/thor
 [codeclimate]: https://codeclimate.com/github/erikhuda/thor
 [coveralls]: https://coveralls.io/r/erikhuda/thor
 


### PR DESCRIPTION
Because gemnasium.com already closed.
Ref: https://docs.gitlab.com/ee/user/project/import/gemnasium.html#why-is-gemnasium-com-closed