### PR TITLE
Add language about how not to use Thor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ utilities.  It removes the pain of parsing command line options, writing
 build tool.  The syntax is Rake-like, so it should be familiar to most Rake
 users.
 
+Please note: Thor, by design, is a system tool created to allow seamless file and url
+access, which should not receive application user input. It relies on open-uri,
+which combined with application user input would provide a command injection attack
+vector.
+
 [rake]: https://github.com/ruby/rake
 
 Installation

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ build tool.  The syntax is Rake-like, so it should be familiar to most Rake
 users.
 
 Please note: Thor, by design, is a system tool created to allow seamless file and url
-access, which should not receive application user input. It relies on open-uri,
+access, which should not receive application user input. It relies on [open-uri][open-uri],
 which combined with application user input would provide a command injection attack
 vector.
 
 [rake]: https://github.com/ruby/rake
+[open-uri]: https://ruby-doc.org/stdlib-2.5.1/libdoc/open-uri/rdoc/index.html
 
 Installation
 ------------


### PR DESCRIPTION
In order to get a clean bill of health from ruby-audit, we should ensure any application developers are aware that they should not just take user input and pass it straight through to Thor.

Might render https://github.com/rubysec/ruby-advisory-db/pull/341 moot?