### PR TITLE
Fix print_wrapped to properly parse "\x5" newline character

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -234,9 +234,9 @@ class Thor
           unwrapped.split(" ").inject do |memo, word|
             word = word.gsub(/\n\005/, "\n").gsub(/\005/, "\n")
             counter = 0 if word.include? "\n"
-            if (counter + word.length + indent) < (width + word.length)
+            if (counter + word.length + 1) < width
               memo = "#{memo} #{word}"
-              counter += word.length+indent
+              counter += (word.length + 1)
             else
               memo = "#{memo}\n#{word}"
               counter = word.length

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -234,7 +234,7 @@ class Thor
           unwrapped.split(" ").inject do |memo, word|
             word = word.gsub(/\n\005/, "\n").gsub(/\005/, "\n")
             counter = 0 if word.include? "\n"
-            if (counter + word.length + indent) < width
+            if (counter + word.length + indent) < (width + word.length)
               memo = "#{memo} #{word}"
               counter += word.length+indent
             else

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -230,8 +230,20 @@ class Thor
         paras = message.split("\n\n")
 
         paras.map! do |unwrapped|
-          unwrapped.strip.tr("\n", " ").squeeze(" ").gsub(/.{1,#{width}}(?:\s|\Z)/) { ($& + 5.chr).gsub(/\n\005/, "\n").gsub(/\005/, "\n") }
-        end
+          counter = 0
+          unwrapped.split(" ").inject do |memo, word|
+            word = word.gsub(/\n\005/, "\n").gsub(/\005/, "\n")
+            counter = 0 if word.include? "\n"
+            if (counter + word.length + indent) < width
+              memo = "#{memo} #{word}"
+              counter += word.length+indent
+            else
+              memo = "#{memo}\n#{word}"
+              counter = word.length
+            end
+            memo
+          end
+        end.compact!
 
         paras.each do |para|
           para.split("\n").each do |line|

--- a/lib/thor/version.rb
+++ b/lib/thor/version.rb
@@ -1,0 +1,3 @@
+class Thor
+  VERSION = "0.20.0"
+end

--- a/lib/thor/version.rb
+++ b/lib/thor/version.rb
@@ -1,3 +1,3 @@
 class Thor
-  VERSION = "0.20.0"
+  VERSION = "0.20.1"
 end

--- a/lib/thor/version.rb
+++ b/lib/thor/version.rb
@@ -1,3 +1,0 @@
-class Thor
-  VERSION = "0.20.1"
-end


### PR DESCRIPTION
:rainbow: Hi there!

While using Thor I found that the print_wrapped function behaves weirdly when manually inserting \x5 sequence (as per your docs) to force a line break. The original function doesn't takes those line breaks into consideration when calculating the length of the line, and the result is some extra weird line breaks on a long paragraph that includes such sequences (e.g. giving several execution examples).

I've rewrote this function, I reckon it's less "stylish", ~~and has a side effect that is unlikely a print_wrapped will use the whole terminal size~~, but it won't break intended multi-line paragraphs either.

Long story short, I'm breaking a paragraph in words, doing the "\x5" to "\n" replacement and keeping a counter that tells me when the line is over the terminal size, so it places a line break.

This change doesn't interfere with core functionality and I've tested it, feel free to review it and if you see fit, merge (I've also increased the version number).

PS: Both in your "master" branch and my fork I'm getting 4 errors related to Readline spec when running `bundle exec thor spec` locally ¯\\\_(ツ)_/¯

Cheers!