### PR TITLE
Fix check_unknown_options! when parsing gets stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix `check_unknown_options!` to not check the content that was not parsed, i.e. after a `--` or after the first unknown with `stop_on_unknown_option!`
+
 ## 0.20.0
 * Add `check_default_type!` to check if the default value of an option matches the defined type.
   It removes the warning on usage and gives the command authors the possibility to check for programming errors.

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -44,6 +44,7 @@ class Thor
       @shorts = {}
       @switches = {}
       @extra = []
+      @stopped_parsing_after_extra_index = nil
 
       options.each do |option|
         @switches[option.switch_name] = option
@@ -66,6 +67,7 @@ class Thor
       if result == OPTS_END
         shift
         @parsing_options = false
+        @stopped_parsing_after_extra_index ||= @extra.size
         super
       else
         result
@@ -99,6 +101,7 @@ class Thor
           elsif @stop_on_unknown
             @parsing_options = false
             @extra << shifted
+            @stopped_parsing_after_extra_index ||= @extra.size
             @extra << shift while peek
             break
           elsif match
@@ -120,8 +123,10 @@ class Thor
     end
 
     def check_unknown!
+      to_check = @stopped_parsing_after_extra_index ? @extra[0...@stopped_parsing_after_extra_index] : @extra
+
       # an unknown option starts with - or -- and has no more --'s afterward.
-      unknown = @extra.select { |str| str =~ /^--?(?:(?!--).)*$/ }
+      unknown = to_check.select { |str| str =~ /^--?(?:(?!--).)*$/ }
       raise UnknownArgumentError, "Unknown switches '#{unknown.join(', ')}'" unless unknown.empty?
     end
 


### PR DESCRIPTION
If the parsing gets stopped by either a `--` or by `#stop_on_unknown_option!`, then `check_unknown_options!` would still try to do validation on the unparsed parts.

This change now tracks where the stop happened and only check the `@extra` that were before that point.

For example, right now, `exec something -- --verbose` would fail because of `unknown switch --verbose` when `check_unknown_options!` is set.