### PR TITLE
Remove duplicate option creation in spec

### DIFF
--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -345,19 +345,16 @@ describe Thor::Options do
       end
 
       it "doesn't eat the next part of the param" do
-        create :foo => :boolean
         expect(parse("--foo", "bar")).to eq("foo" => true)
         expect(@opt.remaining).to eq(%w(bar))
       end
 
       it "doesn't eat the next part of the param with 'no-opt' variant" do
-        create :foo => :boolean
         expect(parse("--no-foo", "bar")).to eq("foo" => false)
         expect(@opt.remaining).to eq(%w(bar))
       end
 
       it "doesn't eat the next part of the param with 'skip-opt' variant" do
-        create :foo => :boolean
         expect(parse("--skip-foo", "bar")).to eq("foo" => false)
         expect(@opt.remaining).to eq(%w(bar))
       end


### PR DESCRIPTION
These three lines are misleading; the option `foo` is already created in the `before` block.