### PR TITLE
Deprecate relying on default exit_on_failure?

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -339,6 +339,13 @@ class Thor
       command && disable_required_check.include?(command.name.to_sym)
     end
 
+    def deprecation_warning(message) #:nodoc:
+      unless ENV['THOR_SILENCE_DEPRECATION']
+        warn "Deprecation warning: #{message}\n" +
+          'You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.'
+      end
+    end
+
   protected
 
     def stop_on_unknown_option #:nodoc:

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -644,6 +644,7 @@ class Thor
 
       # A flag that makes the process exit with status 1 if any error happens.
       def exit_on_failure?
+        Thor.deprecation_warning 'Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?`'
         false
       end
 

--- a/spec/fixtures/command.thor
+++ b/spec/fixtures/command.thor
@@ -1,6 +1,10 @@
 # module: random
 
 class Amazing < Thor
+  def self.exit_on_failure?
+    false
+  end
+
   desc "describe NAME", "say that someone is amazing"
   method_options :forcefully => :boolean
   def describe(name, opts)

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -1,6 +1,10 @@
 class MyScript < Thor
   check_unknown_options! :except => :with_optional
 
+  def self.exit_on_failure?
+    false
+  end
+
   attr_accessor :some_attribute
   attr_writer :another_attribute
   attr_reader :another_attribute
@@ -180,6 +184,10 @@ module Scripts
   class MyDefaults < Thor
     check_unknown_options!
 
+    def self.exit_on_failure?
+      false
+    end
+
     namespace :default
     desc "cow", "prints 'moo'"
     def cow
@@ -200,6 +208,10 @@ module Scripts
   end
 
   class Arities < Thor
+    def self.exit_on_failure?
+      false
+    end
+
     desc "zero_args", "takes zero args"
     def zero_args
     end

--- a/spec/subcommand_spec.rb
+++ b/spec/subcommand_spec.rb
@@ -55,6 +55,10 @@ describe Thor do
       class Parent < Thor
         desc "child1", "child1 description"
         subcommand "child1", Child1
+
+        def self.exit_on_failure?
+          false
+        end
       end
     end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -173,6 +173,10 @@ describe Thor do
         def exec(*args)
           [options, args]
         end
+
+        def self.exit_on_failure?
+          false
+        end
       end
 
       it "passes remaining args to command when it encounters a non-option" do
@@ -222,6 +226,10 @@ describe Thor do
       desc "checked", "a command with checked"
       def checked(*args)
         [options, args]
+      end
+
+      def self.exit_on_failure?
+        false
       end
     end
 
@@ -284,6 +292,10 @@ describe Thor do
       desc "boring", "An ordinary command"
       def boring(*args)
         [options, args]
+      end
+
+      def self.exit_on_failure?
+        false
       end
     end
 
@@ -716,4 +728,19 @@ HELP
       expect(MyScript.start(%w(send))).to eq(true)
     end
   end
+
+  context "without an exit_on_failure? method" do
+    my_script = Class.new(Thor) do
+      desc "no arg", "do nothing"
+      def no_arg
+      end
+    end
+
+    it "outputs a deprecation warning on error" do
+      expect do
+        my_script.start(%w[no_arg one])
+      end.to output(/^Deprecation.*exit_on_failure/).to_stderr
+    end
+  end
+
 end


### PR DESCRIPTION
This forces implementers in defining `exit_on_failure?`, or else a deprecation warning is issued on error. See discussion in #621