### PR TITLE
Abort when `run` subprocess fail

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -255,9 +255,16 @@ class Thor
 
       say_status :run, desc, config.fetch(:verbose, true)
 
-      unless options[:pretend]
-        config[:capture] ? `#{command}` : system(command.to_s)
+      return if options[:pretend]
+
+      result = config[:capture] ? `#{command}` : system(command.to_s)
+
+      if config[:abort_on_failure]
+        success = config[:capture] ? $?.success? : result
+        abort unless success
       end
+
+      result
     end
 
     # Executes a ruby script (taking into account WIN32 platform quirks).

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -291,6 +291,24 @@ describe Thor::Actions do
       end
     end
 
+    describe "aborting on failure" do
+      it "aborts when abort_on_failure is given and command fails" do
+        expect { action :run, "false", :abort_on_failure => true }.to raise_error(SystemExit)
+      end
+
+      it "suceeds when abort_on_failure is given and command succeeds" do
+        expect { action :run, "true", :abort_on_failure => true }.not_to raise_error
+      end
+
+      it "aborts when abort_on_failure is given, capture is given and command fails" do
+        expect { action :run, "false", :abort_on_failure => true, :capture => true }.to raise_error(SystemExit)
+      end
+
+      it "suceeds when abort_on_failure is given and command succeeds" do
+        expect { action :run, "true", :abort_on_failure => true, :capture => true }.not_to raise_error
+      end
+    end
+
     describe "when pretending" do
       it "doesn't execute the command" do
         runner = MyCounter.new([1], %w(--pretend))

--- a/spec/fixtures/bundle/execute.rb
+++ b/spec/fixtures/bundle/execute.rb
@@ -1,6 +1,0 @@
-class Execute < Thor
-  desc "ls", "Execute ls"
-  def ls
-    system "ls"
-  end
-end

--- a/spec/fixtures/bundle/main.thor
+++ b/spec/fixtures/bundle/main.thor
@@ -1,1 +1,0 @@
-require File.join(File.dirname(__FILE__), 'execute')


### PR DESCRIPTION
Hi!

Sometimes my Rails generators that spawn subprocesses crash, and I don't even notice because my build status stays green. I'd like to add a "safe" mode to `run` that when passed makes the process abort if the subcommand fails. 