### PR TITLE
Support did-you-mean functionality in thor

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -493,8 +493,7 @@ class Thor
       alias_method :public_task, :public_command
 
       def handle_no_command_error(command, has_namespace = $thor_runner) #:nodoc:
-        raise UndefinedCommandError, "Could not find command #{command.inspect} in #{namespace.inspect} namespace." if has_namespace
-        raise UndefinedCommandError, "Could not find command #{command.inspect}."
+        raise UndefinedCommandError.new(command, all_commands.keys, (namespace if has_namespace))
       end
       alias_method :handle_no_task_error, :handle_no_command_error
 

--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -1,4 +1,11 @@
 class Thor
+  Correctable =
+    begin
+      require 'did_you_mean'
+      DidYouMean::Correctable
+    rescue LoadError
+    end
+
   # Thor::Error is raised when it's caused by wrong usage of thor classes. Those
   # errors have their backtrace suppressed and are nicely shown to the user.
   #
@@ -38,7 +45,7 @@ class Thor
       super(message)
     end
 
-    prepend DidYouMean::Correctable
+    prepend Correctable if Correctable
   end
   UndefinedTaskError = UndefinedCommandError
 
@@ -78,7 +85,7 @@ class Thor
       super("Unknown switches #{unknown.map(&:inspect).join(', ')}")
     end
 
-    prepend DidYouMean::Correctable
+    prepend Correctable if Correctable
   end
 
   class RequiredArgumentMissingError < InvocationError
@@ -87,8 +94,10 @@ class Thor
   class MalformattedArgumentError < InvocationError
   end
 
-  DidYouMean::SPELL_CHECKERS.merge!(
-    'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
-    'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
-  )
+  if Correctable
+    DidYouMean::SPELL_CHECKERS.merge!(
+      'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
+      'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
+    )
+  end
 end

--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -2,6 +2,20 @@ class Thor
   Correctable =
     begin
       require 'did_you_mean'
+
+      module DidYouMean
+        # In order to support versions of Ruby that don't have keyword
+        # arguments, we need our own spell checker class that doesn't take key
+        # words. Even though this code wouldn't be hit because of the check
+        # above, it's still necessary because the interpreter would otherwise be
+        # unable to parse the file.
+        class NoKwargSpellChecker < SpellChecker
+          def initialize(dictionary)
+            @dictionary = dictionary
+          end
+        end
+      end
+
       DidYouMean::Correctable
     rescue LoadError
     end
@@ -29,7 +43,7 @@ class Thor
       end
 
       def spell_checker
-        DidYouMean::SpellChecker.new(dictionary: error.all_commands)
+        DidYouMean::NoKwargSpellChecker.new(error.all_commands)
       end
     end
 
@@ -72,7 +86,7 @@ class Thor
 
       def spell_checker
         @spell_checker ||=
-          DidYouMean::SpellChecker.new(dictionary: error.switches)
+          DidYouMean::NoKwargSpellChecker.new(error.switches)
       end
     end
 

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -127,7 +127,7 @@ class Thor
 
       # an unknown option starts with - or -- and has no more --'s afterward.
       unknown = to_check.select { |str| str =~ /^--?(?:(?!--).)*$/ }
-      raise UnknownArgumentError, "Unknown switches '#{unknown.join(', ')}'" unless unknown.empty?
+      raise UnknownArgumentError.new(@switches.keys, unknown) unless unknown.empty?
     end
 
   protected

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -263,10 +263,8 @@ describe Thor::Base do
     end
 
     it "suggests commands that are similar if there is a typo" do
-      expected = <<~MSG
-        Could not find command "paintz" in "barn" namespace.
-        Did you mean?  "paint"
-      MSG
+      expected = "Could not find command \"paintz\" in \"barn\" namespace.\n"
+      expected << "Did you mean?  \"paint\"" if Thor::Correctable
 
       expect(capture(:stderr) { Barn.start(%w(paintz)) }).to eq(expected)
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -262,6 +262,15 @@ describe Thor::Base do
       end.to raise_error(Thor::UndefinedCommandError, 'Could not find command "what" in "my_script" namespace.')
     end
 
+    it "suggests commands that are similar if there is a typo" do
+      expected = <<~MSG
+        Could not find command "paintz" in "barn" namespace.
+        Did you mean?  "paint"
+      MSG
+
+      expect(capture(:stderr) { Barn.start(%w(paintz)) }).to eq(expected)
+    end
+
     it "does not steal args" do
       args = %w(foo bar --force true)
       MyScript.start(args)
@@ -271,7 +280,7 @@ describe Thor::Base do
     it "checks unknown options" do
       expect(capture(:stderr) do
         MyScript.start(%w(foo bar --force true --unknown baz))
-      end.strip).to eq("Unknown switches '--unknown'")
+      end.strip).to eq("Unknown switches \"--unknown\"")
     end
 
     it "checks unknown options except specified" do

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -113,7 +113,13 @@ describe Thor::Options do
     it "raises an error for unknown switches" do
       create :foo => "baz", :bar => :required
       parse("--bar", "baz", "--baz", "unknown")
-      expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError, "Unknown switches '--baz'")
+
+      expected = <<~MSG.chomp
+        Unknown switches "--baz"
+        Did you mean?  "--bar"
+      MSG
+
+      expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError, expected)
     end
 
     it "skips leading non-switches" do

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -114,10 +114,8 @@ describe Thor::Options do
       create :foo => "baz", :bar => :required
       parse("--bar", "baz", "--baz", "unknown")
 
-      expected = <<~MSG.chomp
-        Unknown switches "--baz"
-        Did you mean?  "--bar"
-      MSG
+      expected = "Unknown switches \"--baz\""
+      expected << "\nDid you mean?  \"--bar\"" if Thor::Correctable
 
       expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError, expected)
     end

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -182,7 +182,7 @@ describe Thor do
       it "does not accept if first non-option looks like an option, but only refuses that invalid option" do
         expect(capture(:stderr) do
           my_script2.start(%w[exec --foo command --bar])
-        end.strip).to eq("Unknown switches '--foo'")
+        end.strip).to eq("Unknown switches \"--foo\"")
       end
 
       it "still accepts options that are given before non-options" do
@@ -196,7 +196,7 @@ describe Thor do
       it "does not accept when non-option looks like an option and is after real options" do
         expect(capture(:stderr) do
           my_script2.start(%w[exec --verbose --foo])
-        end.strip).to eq("Unknown switches '--foo'")
+        end.strip).to eq("Unknown switches \"--foo\"")
       end
 
       it "still accepts options that require a value" do
@@ -236,25 +236,25 @@ describe Thor do
     it "does not accept if non-option that looks like an option is before the arguments" do
       expect(capture(:stderr) do
         my_script.start(%w[checked --foo command --bar])
-      end.strip).to eq("Unknown switches '--foo, --bar'")
+      end.strip).to eq("Unknown switches \"--foo\", \"--bar\"")
     end
 
     it "does not accept if non-option that looks like an option is after an argument" do
       expect(capture(:stderr) do
         my_script.start(%w[checked command --foo --bar])
-      end.strip).to eq("Unknown switches '--foo, --bar'")
+      end.strip).to eq("Unknown switches \"--foo\", \"--bar\"")
     end
 
     it "does not accept when non-option that looks like an option is after real options" do
       expect(capture(:stderr) do
         my_script.start(%w[checked --verbose --foo])
-      end.strip).to eq("Unknown switches '--foo'")
+      end.strip).to eq("Unknown switches \"--foo\"")
     end
 
     it "does not accept when non-option that looks like an option is before real options" do
       expect(capture(:stderr) do
         my_script.start(%w[checked --foo --verbose])
-      end.strip).to eq("Unknown switches '--foo'")
+      end.strip).to eq("Unknown switches \"--foo\"")
     end
 
     it "still accepts options that require a value" do


### PR DESCRIPTION
When an invocation errors out because it cannot find a corresponding command, this will attempt to suggest alternatives in the case of typos. Also, when invalid switches are passed and checking for invalid switches is enabled, it will attempt to suggest alternatives as well.