### PR TITLE
Remove the globally installed gem by rvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_install:
   - gem update --system
   - gem install bundler
+  - rvm @global do gem uninstall did_you_mean
 bundler_args: --without development
 language: ruby
 rvm:


### PR DESCRIPTION
This fixes follow error:

```
Gem::LoadError: You have already activated did_you_mean 1.2.0, but your Gemfile requires did_you_mean 1.2.1. Prepending `bundle exec` to your command may solve this.
```