### PR TITLE
Add care about old version of `did_you_mean`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,8 @@ group :test do
   else
     gem "webmock"
   end
-  if RUBY_VERSION >= '2.5.0'
+  if RUBY_VERSION >= '1.9'
+    # `did_you_mean` can't build with Ruby 1.8.
     gem 'did_you_mean'
   end
 end

--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -15,7 +15,7 @@ class Thor
       end
 
       DidYouMean::Correctable
-    rescue LoadError
+    rescue LoadError, NameError
     end
 
   # Thor::Error is raised when it's caused by wrong usage of thor classes. Those


### PR DESCRIPTION
`DidYouMean::SpellChecker` class added by `v1.0.2`.
https://github.com/yuki24/did_you_mean/blob/master/CHANGELOG.md#v102

Therefore, even if can use `did_you_mean`, may not be able to use
`DidYouMean::SpellChecker`. For that case, also ignored `NameError`.