### PR TITLE
Do not require did_you_mean

### DIFF
--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -1,22 +1,18 @@
 class Thor
-  Correctable =
-    begin
-      require 'did_you_mean'
+  Correctable = if defined?(DidYouMean::SpellChecker) && defined?(DidYouMean::Correctable)
+                  # In order to support versions of Ruby that don't have keyword
+                  # arguments, we need our own spell checker class that doesn't take key
+                  # words. Even though this code wouldn't be hit because of the check
+                  # above, it's still necessary because the interpreter would otherwise be
+                  # unable to parse the file.
+                  class NoKwargSpellChecker < DidYouMean::SpellChecker # :nodoc:
+                    def initialize(dictionary)
+                      @dictionary = dictionary
+                    end
+                  end
 
-      # In order to support versions of Ruby that don't have keyword
-      # arguments, we need our own spell checker class that doesn't take key
-      # words. Even though this code wouldn't be hit because of the check
-      # above, it's still necessary because the interpreter would otherwise be
-      # unable to parse the file.
-      class NoKwargSpellChecker < DidYouMean::SpellChecker # :nodoc:
-        def initialize(dictionary)
-          @dictionary = dictionary
-        end
-      end
-
-      DidYouMean::Correctable
-    rescue LoadError, NameError
-    end
+                  DidYouMean::Correctable
+                end
 
   # Thor::Error is raised when it's caused by wrong usage of thor classes. Those
   # errors have their backtrace suppressed and are nicely shown to the user.


### PR DESCRIPTION
This caused a drastic performance hit (100x slower) on our JRuby applications because it was requiring `did_you_mean` even though we have:

```
JRUBY_OPTS="--disable:did_you_mean"
```

set. In looking through other libraries that use `did_you_mean`, it looks like a fairly common pattern is to just check if the portions of `did_you_mean` that are needed are defined. I tried to replicate that in this patch.