### PR TITLE
Fix "warning: deprecated Object#=~ is called on Integer"

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -9,7 +9,7 @@ class Thor
       arguments = []
 
       args.each do |item|
-        break if item =~ /^-/
+        break if item.is_a?(String) && item =~ /^-/
         arguments << item
       end
 


### PR DESCRIPTION
`Object#=~` is deprecated in Ruby 2.6.
Ref: https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=65989&view=revision