### PR TITLE
TravisCI: removed Ruby versions < 2.3 since rubygems deprecated them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ before_install:
 bundler_args: --without development
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1


### PR DESCRIPTION
```ruby
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.1.gem (100%)
ERROR:  Error installing rubygems-update:
	rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
```