### PR TITLE
Add :case-insensitive flag to allow case-insensitive matching for :limited_to options 🌈

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -463,8 +463,11 @@ class Thor
       end
 
       def answer_match(possibilities, answer, case_insensitive)
-        return possibilities.detect{ |possibility| possibility == answer } unless case_insensitive
-        possibilities.detect{ |possibility| possibility.downcase == answer.downcase }
+        if case_insensitive
+          possibilities.detect{ |possibility| possibility.downcase == answer.downcase }
+        else
+          possibilities.detect{ |possibility| possibility == answer }
+        end 
       end
 
       def merge(destination, content) #:nodoc:

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -451,14 +451,20 @@ class Thor
 
       def ask_filtered(statement, color, options)
         answer_set = options[:limited_to]
+        case_insensitive = options.fetch(:case_insensitive, false)
         correct_answer = nil
         until correct_answer
           answers = answer_set.join(", ")
           answer = ask_simply("#{statement} [#{answers}]", color, options)
-          correct_answer = answer_set.include?(answer) ? answer : nil
+          correct_answer = answer_match(answer_set, answer, case_insensitive)
           say("Your response must be one of: [#{answers}]. Please try again.") unless correct_answer
         end
         correct_answer
+      end
+
+      def answer_match(possibilities, answer, case_insensitive)
+        return possibilities.detect{ |possibility| possibility == answer } unless case_insensitive
+        possibilities.detect{ |possibility| possibility.downcase == answer.downcase }
       end
 
       def merge(destination, content) #:nodoc:

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -68,17 +68,38 @@ describe Thor::Shell::Basic do
       expect(shell.ask("What's your password?", :echo => false)).to eq("mysecretpass")
     end
 
-    it "prints a message to the user with the available options and determines the correctness of the answer" do
+    it "prints a message to the user with the available options, expects case-sensitive matching, and determines the correctness of the answer" do
       flavors = %w(strawberry chocolate vanilla)
       expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', :limited_to => flavors).and_return("chocolate")
       expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
     end
 
-    it "prints a message to the user with the available options and reasks the question after an incorrect response" do
+    it "prints a message to the user with the available options, expects case-sensitive matching, and reasks the question after an incorrect response" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
       expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', :limited_to => flavors).and_return("moose tracks", "chocolate")
       expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
+    end
+
+    #this one
+    it "prints a message to the user with the available options, expects case-sensitive matching, and reasks the question after a case-insensitive match" do
+      flavors = %w(strawberry chocolate vanilla)
+      expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
+      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', :limited_to => flavors).and_return("cHoCoLaTe", "chocolate")
+      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
+    end
+
+    it "prints a message to the user with the available options, expects case-insensitive matching, and determines the correctness of the answer" do
+      flavors = %w(strawberry chocolate vanilla)
+      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', :limited_to => flavors, :case_insensitive => true).and_return("CHOCOLATE")
+      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
+    end
+
+    it "prints a message to the user with the available options, expects case-insensitive matching, and reasks the question after an incorrect response" do
+      flavors = %w(strawberry chocolate vanilla)
+      expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
+      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', :limited_to => flavors, :case_insensitive => true).and_return("moose tracks", "chocolate")
+      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
     end
 
     it "prints a message to the user containing a default and sets the default if only enter is pressed" do

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -81,7 +81,6 @@ describe Thor::Shell::Basic do
       expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
     end
 
-    #this one
     it "prints a message to the user with the available options, expects case-sensitive matching, and reasks the question after a case-insensitive match" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")


### PR DESCRIPTION
Hey all,

After using thor a bit, I thought it'd be useful to be able to match a limited_to option case-insensitively. I often use it for [y/n] prompts, but having the prompt list out all the possibilities [y, Y, n, N, yes, YES, no, NO], for instance, doesn't looks so great. Adding case-insensitive matching allows me to simplify that prompt to [y, yes, n, no].

After reading the contributing guidelines, I see you'd like documentation updated, though documentation doesn't appear to be in the repo, but in a wiki instead. Let me know if there's anything you'd like to see added to this PR to move forward with it.

Thanks!