### PR TITLE
Allow testing with bundler 2

### DIFF
--- a/thor.gemspec
+++ b/thor.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require "thor/version"
 
 Gem::Specification.new do |spec|
-  spec.add_development_dependency "bundler", "~> 1.0"
+  spec.add_development_dependency "bundler", ">= 1.0", "< 3"
   spec.authors = ["Yehuda Katz", "José Valim"]
   spec.description = "Thor is a toolkit for building powerful command-line interfaces."
   spec.email = "ruby-thor@googlegroups.com"


### PR DESCRIPTION
Otherwise I get the error:

```
$ bundle exec thor spec
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.0)

  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.0)' in any of the relevant sources:
  the local ruby installation

```