### PR TITLE
Abort if the command for `run` fails and `exit_on_failure?` is true

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -259,7 +259,7 @@ class Thor
 
       result = config[:capture] ? `#{command}` : system(command.to_s)
 
-      if config[:abort_on_failure]
+      if config.fetch(:abort_on_failure, self.class.exit_on_failure?)
         success = config[:capture] ? $?.success? : result
         abort unless success
       end

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -506,6 +506,11 @@ class Thor
         raise InvocationError, msg
       end
 
+      # A flag that makes the process exit with status 1 if any error happens.
+      def exit_on_failure?
+        false
+      end
+
     protected
 
       # Prints the class options per group. If an option does not belong to
@@ -639,11 +644,6 @@ class Thor
           end
 
         end
-      end
-
-      # A flag that makes the process exit with status 1 if any error happens.
-      def exit_on_failure?
-        false
       end
 
       #

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -292,20 +292,40 @@ describe Thor::Actions do
     end
 
     describe "aborting on failure" do
-      it "aborts when abort_on_failure is given and command fails" do
-        expect { action :run, "false", :abort_on_failure => true }.to raise_error(SystemExit)
+      context "exit_on_failure? is false" do
+        before do
+          allow(MyCounter).to receive(:exit_on_failure?).and_return(false)
+        end
+
+        it "aborts when abort_on_failure is given and command fails" do
+          expect { action :run, "false", :abort_on_failure => true }.to raise_error(SystemExit)
+        end
+
+        it "suceeds when abort_on_failure is given and command succeeds" do
+          expect { action :run, "true", :abort_on_failure => true }.not_to raise_error
+        end
+
+        it "aborts when abort_on_failure is given, capture is given and command fails" do
+          expect { action :run, "false", :abort_on_failure => true, :capture => true }.to raise_error(SystemExit)
+        end
+
+        it "suceeds when abort_on_failure is given and command succeeds" do
+          expect { action :run, "true", :abort_on_failure => true, :capture => true }.not_to raise_error
+        end
       end
 
-      it "suceeds when abort_on_failure is given and command succeeds" do
-        expect { action :run, "true", :abort_on_failure => true }.not_to raise_error
-      end
+      context "exit_on_failure? is true" do
+        before do
+          allow(MyCounter).to receive(:exit_on_failure?).and_return(true)
+        end
 
-      it "aborts when abort_on_failure is given, capture is given and command fails" do
-        expect { action :run, "false", :abort_on_failure => true, :capture => true }.to raise_error(SystemExit)
-      end
+        it "aborts when command fails even if abort_on_failure is not given" do
+          expect { action :run, "false" }.to raise_error(SystemExit)
+        end
 
-      it "suceeds when abort_on_failure is given and command succeeds" do
-        expect { action :run, "true", :abort_on_failure => true, :capture => true }.not_to raise_error
+        it "does not abort when abort_on_failure is false even if the command fails" do
+          expect { action :run, "false", :abort_on_failure => false }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
Hi, there :rainbow:

I'd like to change the error handling of `Thor::Actions#run` for the following reason. 

According to the description of `exit_on_failure?`, the process should exit with status 1 if any error happens. I think that it should be also applied to `run`.

Although we can pass `abort_on_failure` option for `run`, passing it every time seems a little redundant when we call `run` multiple times. This is the other reason for this change.

For instance, when an error occres [here](https://github.com/rails/webpacker/blob/e95dd724ea3a385b9cc6935c3a07a34f1d1f9657/lib/install/elm.rb#L27), I want to notice not only by the output but also by the status code.