### PR TITLE
Isolate the test from system charset environment

### DIFF
--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -105,8 +105,15 @@ describe Thor::Actions::InjectIntoFile do
     end
 
     it "can insert chinese" do
-      invoke! "doc/README.zh", "\n中文", :after => "__start__"
-      expect(File.read(File.join(destination_root, "doc/README.zh"))).to eq("__start__\n中文\n说明\n__end__\n")
+      encoding_original = Encoding.default_external
+
+      begin
+        Encoding.default_external = Encoding.find("UTF-8")
+        invoke! "doc/README.zh", "\n中文", :after => "__start__"
+        expect(File.read(File.join(destination_root, "doc/README.zh"))).to eq("__start__\n中文\n说明\n__end__\n")
+      ensure
+        Encoding.default_external = encoding_original
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

when the testing system uses non-chinese charset (eg. `US-ASCII`), the test comes fail.

This patch will isolate the test from local system environment.