### PR TITLE
fix rescue of OpenURI

### DIFF
--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -7,6 +7,8 @@ require "digest/md5"
 require "pathname"
 
 class Thor::Runner < Thor #:nodoc: # rubocop:disable ClassLength
+  autoload :OpenURI, "open-uri"
+
   map "-T" => :list, "-i" => :install, "-u" => :update, "-v" => :version
 
   def self.banner(command, all = false, subcommand = false)


### PR DESCRIPTION
🌈 

If an error is raised by `thor install` because of an invalid URI, the rescue block currently fails because it [references OpenURI](https://github.com/erikhuda/thor/blob/master/lib/thor/runner.rb#L62) and is not loaded. Update to load as needed.

reproduce with `bundle exec thor install foo`

