### PR TITLE
Call super in hook methods

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -89,6 +89,7 @@ class Thor
 
     class << self
       def included(base) #:nodoc:
+        super(base)
         base.extend ClassMethods
         base.send :include, Invocation
         base.send :include, Shell
@@ -596,6 +597,7 @@ class Thor
       # Everytime someone inherits from a Thor class, register the klass
       # and file into baseclass.
       def inherited(klass)
+        super(klass)
         Thor::Base.register_klass_file(klass)
         klass.instance_variable_set(:@no_commands, false)
       end
@@ -603,6 +605,7 @@ class Thor
       # Fire this callback whenever a method is added. Added methods are
       # tracked as commands by invoking the create_command method.
       def method_added(meth)
+        super(meth)
         meth = meth.to_s
 
         if meth == "initialize"

--- a/lib/thor/rake_compat.rb
+++ b/lib/thor/rake_compat.rb
@@ -25,6 +25,7 @@ class Thor
     end
 
     def self.included(base)
+      super(base)
       # Hack. Make rakefile point to invoker, so rdoc task is generated properly.
       rakefile = File.basename(caller[0].match(/(.*):\d+/)[1])
       Rake.application.instance_variable_set(:@rakefile, rakefile)


### PR DESCRIPTION
This PR makes it so that we call `super` in various hook methods.

The default implementation of these methods (on Module) is just to no-op, so this ought to be safe to do.

This allows for other people to come along and add things to those hook methods (either before or after us), and as long as everyone supers up, all the hooks should get called as desired.