### PR TITLE
Use absolute paths for internal autoloads

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -8,9 +8,9 @@ require_relative "line_editor"
 require_relative "util"
 
 class Thor
-  autoload :Actions,    "thor/actions"
-  autoload :RakeCompat, "thor/rake_compat"
-  autoload :Group,      "thor/group"
+  autoload :Actions,    File.expand_path("actions", __dir__)
+  autoload :RakeCompat, File.expand_path("rake_compat", __dir__)
+  autoload :Group,      File.expand_path("group", __dir__)
 
   # Shortcuts for help.
   HELP_MAPPINGS       = %w(-h -? --help -D)

--- a/lib/thor/shell.rb
+++ b/lib/thor/shell.rb
@@ -24,9 +24,9 @@ class Thor
     SHELL_DELEGATED_METHODS = [:ask, :error, :set_color, :yes?, :no?, :say, :say_status, :print_in_columns, :print_table, :print_wrapped, :file_collision, :terminal_width]
     attr_writer :shell
 
-    autoload :Basic, "thor/shell/basic"
-    autoload :Color, "thor/shell/color"
-    autoload :HTML,  "thor/shell/html"
+    autoload :Basic, File.expand_path("shell/basic", __dir__)
+    autoload :Color, File.expand_path("shell/color", __dir__)
+    autoload :HTML,  File.expand_path("shell/html", __dir__)
 
     # Add shell to initialize config values.
     #


### PR DESCRIPTION
This is a follow up to #668.

In bundler, I didn't want to rely on the LOAD_PATH for any internal requires because of the reasons given in #668.

But there's no `autoload_relative` in ruby, although there's a feature request: https://bugs.ruby-lang.org/issues/15330.

So my workaround was to instead require an absolute path, so that the LOAD_PATH is still not used.