### PR TITLE
Support the keyword separation feature on Ruby 2.7

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -90,9 +90,14 @@ class Thor
     # ==== Parameters
     # Hash[String|Array => Symbol]:: Maps the string or the strings in the array to the given command.
     #
-    def map(mappings = nil)
+    def map(mappings = nil, **kw)
       @map ||= from_superclass(:map, {})
 
+      if mappings && !kw.empty?
+        mappings = kw.merge!(mappings)
+      else
+        mappings ||= kw
+      end
       if mappings
         mappings.each do |key, value|
           if key.respond_to?(:each)


### PR DESCRIPTION
backport from https://github.com/bundler/bundler/commit/da7e1f55c86fd65001cf36ea6af86bdd88417161

Co-authored-by: Jeremy Evans <code@jeremyevans.net>

/cc @jeremyevans