### PR TITLE
Allow Option to be repeatable

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -1,17 +1,18 @@
 class Thor
   class Option < Argument #:nodoc:
-    attr_reader :aliases, :group, :lazy_default, :hide
+    attr_reader :aliases, :group, :lazy_default, :hide, :repeatable
 
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
     def initialize(name, options = {})
       @check_default_type = options[:check_default_type]
       options[:required] = false unless options.key?(:required)
+      @repeatable     = options.fetch(:repeatable, false)
       super
-      @lazy_default = options[:lazy_default]
-      @group        = options[:group].to_s.capitalize if options[:group]
-      @aliases      = Array(options[:aliases])
-      @hide         = options[:hide]
+      @lazy_default   = options[:lazy_default]
+      @group          = options[:group].to_s.capitalize if options[:group]
+      @aliases        = Array(options[:aliases])
+      @hide           = options[:hide]
     end
 
     # This parse quick options given as method_options. It makes several
@@ -128,7 +129,8 @@ class Thor
         @default.class.name.downcase.to_sym
       end
 
-      raise ArgumentError, "Expected #{@type} default value for '#{switch_name}'; got #{@default.inspect} (#{default_type})" unless default_type == @type
+      expected_type = (@repeatable && @type != :hash) ? :array : @type
+      raise ArgumentError, "Expected #{expected_type} default value for '#{switch_name}'; got #{@default.inspect} (#{default_type})" unless default_type == expected_type
     end
 
     def dasherized?

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -97,7 +97,8 @@ class Thor
 
             switch = normalize_switch(switch)
             option = switch_option(switch)
-            @assigns[option.human_name] = parse_peek(switch, option)
+            result = parse_peek(switch, option)
+            assign_result!(option, result)
           elsif @stop_on_unknown
             @parsing_options = false
             @extra << shifted
@@ -132,6 +133,15 @@ class Thor
 
   protected
 
+  def assign_result!(option, result)
+    if option.repeatable && option.type == :hash
+      (@assigns[option.human_name] ||= {}).merge!(result)
+    elsif option.repeatable
+      (@assigns[option.human_name] ||= []) << result
+    else
+      @assigns[option.human_name] = result
+    end
+  end
     # Check if the current value in peek is a registered switch.
     #
     # Two booleans are returned.  The first is true if the current value

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -140,6 +140,30 @@ describe Thor::Option do
     end.to raise_error(ArgumentError, 'Expected numeric default value for \'--foo-bar\'; got "baz" (string)')
   end
 
+  it "raises an error if repeatable and default is inconsistent with type and check_default_type is true" do
+    expect do
+      option("foo_bar", :type => :numeric, :repeatable => true, :default => "baz", :check_default_type => true)
+    end.to raise_error(ArgumentError, 'Expected array default value for \'--foo-bar\'; got "baz" (string)')
+  end
+
+  it "raises an error type hash is repeatable and default is inconsistent with type and check_default_type is true" do
+    expect do
+      option("foo_bar", :type => :hash, :repeatable => true, :default => "baz", :check_default_type => true)
+    end.to raise_error(ArgumentError, 'Expected hash default value for \'--foo-bar\'; got "baz" (string)')
+  end
+
+  it "does not raises an error if type hash is repeatable and default is consistent with type and check_default_type is true" do
+    expect do
+      option("foo_bar", :type => :hash, :repeatable => true, :default => {}, :check_default_type => true)
+    end.not_to raise_error
+  end
+
+  it "does not raises an error if repeatable and default is consistent with type and check_default_type is true" do
+    expect do
+      option("foo_bar", :type => :numeric, :repeatable => true, :default => [1], :check_default_type => true)
+    end.not_to raise_error
+  end
+
   it "does not raises an error if default is an symbol and type string and check_default_type is true" do
     expect do
       option("foo", :type => :string, :default => :bar, :check_default_type => true)


### PR DESCRIPTION
This PR pickups where https://github.com/erikhuda/thor/pull/468#issuecomment-279286148 left off. It adds a new option to `Option`: `:repeatable`. This allows a flag to be repeated and the results collected into an array. The one exceptions is for type Hash, where I merge the hashes into a a single hash. If we'd prefer an array of hashes, I'll be happy to change the behavior. 

I'm happy to write up some docs, though not sure where to do that. 

I've read the contributing guidelines 🌈.
cc: @rafaelfranca 