### PR TITLE
Suppress `URI.open` warning in Ruby 2.7

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -80,13 +80,13 @@ class Thor
       config = args.last.is_a?(Hash) ? args.pop : {}
       destination = args.first
 
-      if source =~ %r{^https?\://}
+      render = if source =~ %r{^https?\://}
         require "open-uri"
+        URI.send(:open, source) { |input| input.binmode.read }
       else
         source = File.expand_path(find_in_source_paths(source.to_s))
+        open(source) { |input| input.binmode.read }
       end
-
-      render = open(source) { |input| input.binmode.read }
 
       destination ||= if block_given?
         block.arity == 1 ? yield(render) : yield


### PR DESCRIPTION
This PR suppresses the follwoing warning in Ruby 2.7

```console
% ruby -v
ruby 2.7.0dev (2019-09-14T09:21:37Z master 39c37acf86) [x86_64-darwin17]
% bundle exec thor spec
(snip)

/Users/koic/src/github.com/erikhuda/thor/lib/ty
./Users/koic/src/github.com/erikhuda/thor/lib/thor/actions/file_manipulation.rb:89:
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly
```

cf https://github.com/ruby/ruby/commit/05aac90a1bcfeb180f5e78ea8b00a4d1b04d5eed.