### PR TITLE
Fix `--skip-foo` switches when there's a trailing non-switch

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -196,7 +196,10 @@ class Thor
     # Parse boolean values which can be given as --foo=true, --foo or --no-foo.
     #
     def parse_boolean(switch)
-      if current_is_value?
+      no_or_skip = no_or_skip?(switch)
+      if no_or_skip
+        @switches.key?(switch) || !no_or_skip
+      elsif current_is_value?
         if ["true", "TRUE", "t", "T", true].include?(peek)
           shift
           true
@@ -204,10 +207,10 @@ class Thor
           shift
           false
         else
-          !no_or_skip?(switch)
+          !no_or_skip
         end
       else
-        @switches.key?(switch) || !no_or_skip?(switch)
+        @switches.key?(switch) || !no_or_skip
       end
     end
 

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -337,6 +337,10 @@ describe Thor::Options do
         expect(parse("--skip-foo")["foo"]).to eq(false)
       end
 
+      it "accepts --[skip-]opt variant, setting false for value, even if there's a trailing non-switch" do
+        expect(parse("--skip-foo", "asdf")["foo"]).to eq(false)
+      end
+
       it "will prefer 'no-opt' variant over inverting 'opt' if explicitly set" do
         create "--no-foo" => true
         expect(parse("--no-foo")["no-foo"]).to eq(true)
@@ -345,6 +349,11 @@ describe Thor::Options do
       it "will prefer 'skip-opt' variant over inverting 'opt' if explicitly set" do
         create "--skip-foo" => true
         expect(parse("--skip-foo")["skip-foo"]).to eq(true)
+      end
+
+      it "will prefer 'skip-opt' variant over inverting 'opt' if explicitly set, even if there's a trailing non-switch" do
+        create "--skip-foo" => true
+        expect(parse("--skip-foo", "asdf")["skip-foo"]).to eq(true)
       end
 
       it "accepts inputs in the human name format" do


### PR DESCRIPTION
I was running  the command `bundle exec rails new --dev --skip-webpack-install my_project` inside my Rails clone, but Rails generators kept running `--skip-webpack-install`.

Turns out `thor` was considering `my_project` as the value for the `--skip-webpack-install` switch. However, I think the command line I specified is correct and non-ambiguous and that `--no-` and `--skip-` flags are not supposed to have a value.

This PR fixes this edge case.

It adds to tests, the first one is already passing against master, the second one is fixed by this PR. So, I think it also makes the behaviour more consistent.

Fixes #580.