### PR TITLE
Amend `--skip-foo` fix with a trailing option

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -171,7 +171,7 @@ class Thor
     end
 
     def switch?(arg)
-      switch_option(normalize_switch(arg))
+      !switch_option(normalize_switch(arg)).nil?
     end
 
     def switch_option(arg)

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -196,10 +196,7 @@ class Thor
     # Parse boolean values which can be given as --foo=true, --foo or --no-foo.
     #
     def parse_boolean(switch)
-      no_or_skip = no_or_skip?(switch)
-      if no_or_skip
-        @switches.key?(switch) || !no_or_skip
-      elsif current_is_value?
+      if current_is_value?
         if ["true", "TRUE", "t", "T", true].include?(peek)
           shift
           true
@@ -207,10 +204,10 @@ class Thor
           shift
           false
         else
-          !no_or_skip
+          @switches.key?(switch) || !no_or_skip?(switch)
         end
       else
-        @switches.key?(switch) || !no_or_skip
+        @switches.key?(switch) || !no_or_skip?(switch)
       end
     end
 

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -356,6 +356,14 @@ describe Thor::Options do
         expect(parse("--skip-foo", "asdf")["skip-foo"]).to eq(true)
       end
 
+      it "will prefer 'skip-opt' variant over inverting 'opt' if explicitly set, and given a value" do
+        create "--skip-foo" => true
+        expect(parse("--skip-foo=f")["skip-foo"]).to eq(false)
+        expect(parse("--skip-foo=false")["skip-foo"]).to eq(false)
+        expect(parse("--skip-foo=t")["skip-foo"]).to eq(true)
+        expect(parse("--skip-foo=true")["skip-foo"]).to eq(true)
+      end
+
       it "accepts inputs in the human name format" do
         create :foo_bar => :boolean
         expect(parse("--foo-bar")["foo_bar"]).to eq(true)


### PR DESCRIPTION
The fix in bdb43eb unintentioanlly dropped support for specifying things like `--skip-foo=f` or `--skip-foo true`. In the first case, for no good reason, in the second, because "true" is now interpreted as a command option, not as a flag.

This PR restores support for those, so that arguments right after `--skip-foo` flags will never be interpreted as the flag's value, unless they are "true", "t", "false", or "f".

So

`my_program --skip-foo true`

means

"run my_program without arguments and the 'foo' flag unset".
    
whereas

`my_program --skip-foo asdf`

means

"run my_program with argument 'asdf' and the 'foo' flag unset".

By doing this, we still fix what #679 intended to fix, but still retain maximum backwards compatibility and flexibility.

