### PR TITLE
Respect the use of the NO_COLOR environment variable

### DIFF
--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -97,7 +97,11 @@ class Thor
     protected
 
       def can_display_colors?
-        stdout.tty?
+        stdout.tty? && !are_colors_disabled?
+      end
+
+      def are_colors_disabled?
+        !ENV['NO_COLOR'].nil?
       end
 
       # Overwrite show_diff to show diff with colors if Diff::LCS is


### PR DESCRIPTION
🌈 An informal standard for disabling color codes across the many command line tools that output terminal color codes has been described at [https://no-color.org](https://no-color.org)

Many of the tools that I already use have begun to support the variable, and having it in Thor would eventually allow most of the Ruby ecosystem tools I support to gain the functionality as well.

This PR scratches this itch by implementing NO_COLOR as [https://no-color.org](https://no-color.org) defines it:

> All command-line software which outputs text with ANSI color added should check for the presence of a NO_COLOR environment variable that, when present (regardless of its value), prevents the addition of ANSI color.

I'm unsure where the correct place to document this functionality might be. I grepped the source for permutations of "color" and "tty" to to cover the existing functionality. I'm happy to adjust this PR to include documentation if preferred. Just let me know if you want it and whether you have a preference for where it should be.