### PR TITLE
Fix uninitialized global variable warning

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -398,6 +398,7 @@ class Thor
     # the namespace should be displayed as arguments.
     #
     def banner(command, namespace = nil, subcommand = false)
+      $thor_runner ||= false
       command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |formatted_usage|
         "#{basename} #{formatted_usage}"
       end.join("\n")

--- a/spec/fixtures/verbose.thor
+++ b/spec/fixtures/verbose.thor
@@ -1,0 +1,10 @@
+#!/usr/bin/ruby
+
+$VERBOSE = true
+
+require 'thor'
+
+class Test < Thor
+end
+
+Test.start(ARGV)

--- a/spec/no_warnings_spec.rb
+++ b/spec/no_warnings_spec.rb
@@ -1,0 +1,10 @@
+require "open3"
+
+context "when $VERBOSE is enabled" do
+  it "prints no warnings" do
+    root = File.expand_path("..", __dir__)
+    _, err, _ = Open3.capture3("ruby -I #{root}/lib #{root}/spec/fixtures/verbose.thor")
+
+    expect(err).to be_empty
+  end
+end


### PR DESCRIPTION
In particular,

```
 warning: global variable `$thor_runner' not initialized
```

Fixes #633.