### PR TITLE
Lazily require `readline`

### DIFF
--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -1,12 +1,12 @@
-begin
-  require "readline"
-rescue LoadError
-end
-
 class Thor
   module LineEditor
     class Readline < Basic
       def self.available?
+        begin
+          require "readline"
+        rescue LoadError
+        end
+
         Object.const_defined?(:Readline)
       end
 


### PR DESCRIPTION
The current implementation of `readline` has issues under Windows, and those issues sometimes prevent `thor` from being used.

For example, in our bundler Windows CI, we had to patch `rb-readline` to workaround some issues
because `rb-readline` (the default `readline` provider on Windows) couldn't be required. Moreover, we still get some issues when requiring `rb-readline` like

```
HOME environment variable (or HOMEDRIVE and HOMEPATH) must be set and point to a directory
```

Since in some situations the part of thor using `readline` (`Thor::LineEditor`) is not required, for example, in most of CI situations. I thought it could be a good idea to lazily require `readline`.

Just to be clear, this is not a problem with `thor` at all, but since requiring unnecessary things lazily is usually a good thing, I figured we could do this.

Also, an alternative version of this patch would be to autoload `Thor::LineEditor`, like

```diff
diff --git a/lib/thor/base.rb b/lib/thor/base.rb
index 26132de..3bbbbd2 100644
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -4,7 +4,6 @@ require_relative "error"
 require_relative "invocation"
 require_relative "parser"
 require_relative "shell"
-require_relative "line_editor"
 require_relative "util"
 
 class Thor
diff --git a/lib/thor/shell/basic.rb b/lib/thor/shell/basic.rb
index 49e4cb2..9a48e8b 100644
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -1,4 +1,6 @@
 class Thor
+  autoload :LineEditor, "thor/line_editor"
+
   module Shell
     class Basic
       DEFAULT_TERMINAL_WIDTH = 80
```