### PR TITLE
Restore old check on `completion_proc=`

### DIFF
--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -13,7 +13,10 @@ class Thor
       def readline
         if echo?
           ::Readline.completion_append_character = nil
-          ::Readline.completion_proc = completion_proc
+          # rb-readline does not allow Readline.completion_proc= to receive nil.
+          if complete = completion_proc
+            ::Readline.completion_proc = complete
+          end
           ::Readline.readline(prompt, add_to_history?)
         else
           super

--- a/spec/line_editor/readline_spec.rb
+++ b/spec/line_editor/readline_spec.rb
@@ -23,14 +23,14 @@ describe Thor::LineEditor::Readline do
   describe "#readline" do
     it "invokes the readline library" do
       expect(::Readline).to receive(:readline).with("> ", true).and_return("foo")
-      expect(::Readline).to receive(:completion_proc=)
+      expect(::Readline).to_not receive(:completion_proc=)
       editor = Thor::LineEditor::Readline.new("> ", {})
       expect(editor.readline).to eq("foo")
     end
 
     it "supports the add_to_history option" do
       expect(::Readline).to receive(:readline).with("> ", false).and_return("foo")
-      expect(::Readline).to receive(:completion_proc=)
+      expect(::Readline).to_not receive(:completion_proc=)
       editor = Thor::LineEditor::Readline.new("> ", :add_to_history => false)
       expect(editor.readline).to eq("foo")
     end


### PR DESCRIPTION
When dropping `1.8.7` support, I blindly removed this check, because the comment above it [suggested that it was 1.8.7-specific](https://github.com/erikhuda/thor/commit/ae4a3d50cd0d76a77aff80016171944958e0b22e#diff-bed9e34af04cfa7d71087d910326d750L16).

However, the check is also needed for `rb-readline`, the default readline implementation on modern rubies under Windows. See https://github.com/ConnorAtherton/rb-readline/blob/9fba246073f78831b7c7129c76cc07d8476a8892/lib/readline.rb#L91-L97.

So, I'm restoring the check, and the [specs changes](https://github.com/erikhuda/thor/commit/ae4a3d50cd0d76a77aff80016171944958e0b22e#diff-206c6f5b8b9cf96f472e3986abce7fbbL26-L33) that I included in the 1.8.7 support drop commit to get specs passing.