### PR TITLE
 🌈 More accurate Arguments#current_is_value? check

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -82,7 +82,7 @@ class Thor
     end
 
     def current_is_value?
-      peek && peek.to_s !~ /^-/
+      peek && peek.to_s !~ /^-{1,2}\S+/
     end
 
     # Runs through the argument array getting strings that contains ":" and

--- a/spec/parser/arguments_spec.rb
+++ b/spec/parser/arguments_spec.rb
@@ -40,6 +40,12 @@ describe Thor::Arguments do
       expect(parse("product", "title", "age")["array"]).to eq(%w(title age))
     end
 
+    it "accepts - as an array argument" do
+      create :array => nil
+      expect(parse("-")["array"]).to eq(%w(-))
+      expect(parse("-", "title", "-")["array"]).to eq(%w(- title -))
+    end
+
     describe "with no inputs" do
       it "and no arguments returns an empty hash" do
         create


### PR DESCRIPTION
### Motivation

For a number of tools, the argument `-` is often treated to mean STDIN. Currently, Thor is unable to accept `-` as an argument _value_, since it defines a flag as any entry beginning with `-`. This seems overly restrictive. I would argue that a flag is defined as follows:

>A flag is any entry that begins with 1 or 2 dashes, followed by _at least_ one character

In regex terms, this is `/-{1,2}\S+/`.

### TODO 
- [x] update/create tests
- [x] update docs, if necessary _(edit: does not appear necessary to update any docs)_