### PR TITLE
Remove unnecessary "uri" require

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -1,4 +1,3 @@
-require "uri"
 require "open3"
 require_relative "actions/create_file"
 require_relative "actions/create_link"


### PR DESCRIPTION
It's not used anywhere, as far as I can see.