### PR TITLE
Lazily load open3

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -1,4 +1,3 @@
-require "open3"
 require_relative "actions/create_file"
 require_relative "actions/create_link"
 require_relative "actions/directory"
@@ -260,6 +259,7 @@ class Thor
       env_splat = [config[:env]] if config[:env]
 
       if config[:capture]
+        require "open3"
         result, status = Open3.capture2e(*env_splat, command.to_s)
         success = status.success?
       else


### PR DESCRIPTION
It's only used under very specific circumstances, so we can load it only when needed.