### PR TITLE
Allow for nested no_commands blocks.

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -2,6 +2,7 @@ require_relative "command"
 require_relative "core_ext/hash_with_indifferent_access"
 require_relative "error"
 require_relative "invocation"
+require_relative "nested_context"
 require_relative "parser"
 require_relative "shell"
 require_relative "line_editor"
@@ -418,13 +419,19 @@ class Thor
       #     remove_command :this_is_not_a_command
       #   end
       #
-      def no_commands
-        @no_commands = true
-        yield
-      ensure
-        @no_commands = false
+      def no_commands(&block)
+        no_commands_context.enter(&block)
       end
+
       alias_method :no_tasks, :no_commands
+
+      def no_commands_context
+        @no_commands_context ||= NestedContext.new
+      end
+
+      def no_commands?
+        no_commands_context.entered?
+      end
 
       # Sets the namespace for the Thor or Thor::Group class. By default the
       # namespace is retrieved from the class name. If your Thor class is named
@@ -607,7 +614,7 @@ class Thor
       def inherited(klass)
         super(klass)
         Thor::Base.register_klass_file(klass)
-        klass.instance_variable_set(:@no_commands, false)
+        klass.instance_variable_set(:@no_commands, 0)
       end
 
       # Fire this callback whenever a method is added. Added methods are
@@ -624,8 +631,7 @@ class Thor
         # Return if it's not a public instance method
         return unless public_method_defined?(meth.to_sym)
 
-        @no_commands ||= false
-        return if @no_commands || !create_command(meth)
+        return if no_commands? || !create_command(meth)
 
         is_thor_reserved_word?(meth, :command)
         Thor::Base.register_klass_file(self)

--- a/lib/thor/nested_context.rb
+++ b/lib/thor/nested_context.rb
@@ -1,0 +1,29 @@
+class Thor
+  class NestedContext
+    def initialize
+      @depth = 0
+    end
+
+    def enter
+      push
+
+      yield
+    ensure
+      pop
+    end
+
+    def entered?
+      @depth > 0
+    end
+
+    private
+
+    def push
+      @depth += 1
+    end
+
+    def pop
+      @depth -= 1
+    end
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -49,6 +49,7 @@ describe Thor::Base do
     it "avoids methods being added as commands" do
       expect(MyScript.commands.keys).to include("animal")
       expect(MyScript.commands.keys).not_to include("this_is_not_a_command")
+      expect(MyScript.commands.keys).not_to include("neither_is_this")
     end
   end
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -28,7 +28,12 @@ class MyScript < Thor
   desc "animal TYPE", "horse around"
 
   no_commands do
-    def this_is_not_a_command
+    no_commands do
+      def this_is_not_a_command
+      end
+    end
+
+    def neither_is_this
     end
   end
 

--- a/spec/nested_context_spec.rb
+++ b/spec/nested_context_spec.rb
@@ -1,0 +1,20 @@
+require "helper"
+
+describe Thor::NestedContext do
+  subject(:context) { described_class.new }
+  
+  describe "#enter" do
+    it "is never empty within the entered block" do
+      context.enter do
+        context.enter {}
+
+        expect(context).to be_entered
+      end
+    end
+
+    it "is empty when outside of all blocks" do
+      context.enter { context.enter {} }
+      expect(context).not_to be_entered
+    end
+  end
+end


### PR DESCRIPTION
## Allow for nested `no_commands` blocks.  🌈 

### Background
In certain circumstances we may wish to nest `no_commands` blocks.

However, since when exiting the `no_commands` block the `@no_commands`
instance var is reset to `false`, we get unexpected behaviour.

For example, this will show warnings stating that the method `foo` is missing usage and a description:

```ruby
class Foo < Thor

  no_method do
    attr_reader :bar

    def foo
      'foo!'
    end
  end
end
```

This particular example is trivially solved but things get more difficult when, say, including modules.

```ruby
# lib/thor/base.rb
def no_commands
  @no_commands = true
  yield
ensure
   @no_commands = false
end
```

### Solution

This change uses a `NestedContext` object to track the depth of the `no_command` blocks and ensure that we only start creating commands again once we've left all of them.

### Comments

- I'm definitely not sold on the name `NestedContext`