### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/thor.gemspec
+++ b/thor.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://whatisthor.com/"
   spec.licenses = %w(MIT)
   spec.name = "thor"
+  spec.metadata = {
+    "bug_tracker_uri" => "https://github.com/erikhuda/thor/issues",
+    "changelog_uri" => "https://github.com/erikhuda/thor/blob/master/CHANGELOG.md",
+    "documentation_uri" => "http://whatisthor.com/",
+    "source_code_uri" => "https://github.com/erikhuda/thor/tree/v#{Thor::VERSION}",
+    "wiki_uri" => "https://github.com/erikhuda/thor/wiki"
+  }
   spec.require_paths = %w(lib)
   spec.required_ruby_version = ">= 2.0.0"
   spec.required_rubygems_version = ">= 1.3.5"


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/thor), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.