### PR TITLE
Move deprecation_warning to lib/thor/base.rb

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -344,13 +344,6 @@ class Thor
       command && disable_required_check.include?(command.name.to_sym)
     end
 
-    def deprecation_warning(message) #:nodoc:
-      unless ENV['THOR_SILENCE_DEPRECATION']
-        warn "Deprecation warning: #{message}\n" +
-          'You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.'
-      end
-    end
-
   protected
 
     def stop_on_unknown_option #:nodoc:

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -22,6 +22,15 @@ class Thor
 
   TEMPLATE_EXTNAME = ".tt"
 
+  class << self
+    def deprecation_warning(message) #:nodoc:
+      unless ENV['THOR_SILENCE_DEPRECATION']
+        warn "Deprecation warning: #{message}\n" +
+          'You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.'
+      end
+    end
+  end
+
   module Base
     attr_accessor :options, :parent_options, :args
 


### PR DESCRIPTION
Make deprecation_warning available in Thor::Base and Thor::Option when
"thor" is not required, by moving it to "lib/thor/base.rb" which will
be required.

[Fixes #703]