### PR TITLE
Don't use ANSI colors when terminal is dumb

### DIFF
--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -97,7 +97,11 @@ class Thor
     protected
 
       def can_display_colors?
-        stdout.tty? && !are_colors_disabled?
+        are_colors_supported? && !are_colors_disabled?
+      end
+
+      def are_colors_supported?
+        stdout.tty? && ![nil, "dumb"].include?(ENV["TERM"])
       end
 
       def are_colors_disabled?

--- a/spec/shell/color_spec.rb
+++ b/spec/shell/color_spec.rb
@@ -7,6 +7,8 @@ describe Thor::Shell::Color do
 
   before do
     allow($stdout).to receive(:tty?).and_return(true)
+    allow(ENV).to receive(:[]).and_return(nil)
+    allow(ENV).to receive(:[]).with("TERM").and_return("ansi")
     allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
   end
 
@@ -131,13 +133,25 @@ describe Thor::Shell::Color do
       expect(colorless).to eq("hi!")
     end
 
-    it "does nothing when the terminal does not support color" do
+    it "does nothing when stdout is not a tty" do
       allow($stdout).to receive(:tty?).and_return(false)
       colorless = shell.set_color "hi!", :white
       expect(colorless).to eq("hi!")
     end
 
-    it "does nothing when the terminal has the NO_COLOR environment variable set" do
+    it "does nothing when the TERM environment variable is set to 'dumb'" do
+      allow(ENV).to receive(:[]).with("TERM").and_return("dumb")
+      colorless = shell.set_color "hi!", :white
+      expect(colorless).to eq("hi!")
+    end
+
+    it "does nothing when the TERM environment variable is not set" do
+      allow(ENV).to receive(:[]).with("TERM").and_return(nil)
+      colorless = shell.set_color "hi!", :white
+      expect(colorless).to eq("hi!")
+    end
+
+    it "does nothing when the NO_COLOR environment variable is set" do
       allow(ENV).to receive(:[]).with("NO_COLOR").and_return("")
       allow($stdout).to receive(:tty?).and_return(true)
       colorless = shell.set_color "hi!", :white


### PR DESCRIPTION
🌈

It is possible for stdout to be a tty and still not support ANSI colors.  One example of this is the `:!` command in GVim or MacVim.  I had long assumed that the only way to reliably detect this was to introduce a heavyweight dependency such as libncurses, but recently I learned that checking that the environment variable `TERM` is set to a value other than `dumb` is largely sufficient.  This is what Git does, for example:

https://github.com/git/git/blob/0d0ac3826a3bbb9247e39e12623bbcfdd722f24c/editor.c#L11-L15

This patch implements identical behavior for Thor.