### PR TITLE
Restore colors when TERM is unset

### DIFF
--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -101,7 +101,7 @@ class Thor
       end
 
       def are_colors_supported?
-        stdout.tty? && ![nil, "dumb"].include?(ENV["TERM"])
+        stdout.tty? && ENV["TERM"] != "dumb"
       end
 
       def are_colors_disabled?

--- a/spec/shell/color_spec.rb
+++ b/spec/shell/color_spec.rb
@@ -145,12 +145,6 @@ describe Thor::Shell::Color do
       expect(colorless).to eq("hi!")
     end
 
-    it "does nothing when the TERM environment variable is not set" do
-      allow(ENV).to receive(:[]).with("TERM").and_return(nil)
-      colorless = shell.set_color "hi!", :white
-      expect(colorless).to eq("hi!")
-    end
-
     it "does nothing when the NO_COLOR environment variable is set" do
       allow(ENV).to receive(:[]).with("NO_COLOR").and_return("")
       allow($stdout).to receive(:tty?).and_return(true)


### PR DESCRIPTION
🌈

When I added this behavior, I wasn't taking Windows into account.  My inspiration Git handles it by [defaulting `TERM` on Windows](https://github.com/git/git/blob/0d0ac3826a3bbb9247e39e12623bbcfdd722f24c/compat/mingw.c#L2414-L2416), but Ruby has no such equivalent.  I don't think `TERM` will ever be missing on UNIX under normal tty circumstances, so I think it's safe to drop the guard on all platforms.

Thanks for your patience!