### PR TITLE
🌈 Update `Thor::Actions#inside` to return the value yielded by the block

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -161,6 +161,8 @@ class Thor
     # to the block you provide. The path is set back to the previous path when
     # the method exits.
     #
+    # Returns the value yielded by the block.
+    #
     # ==== Parameters
     # dir<String>:: the directory to move to.
     # config<Hash>:: give :verbose => true to log and use padding.
@@ -179,7 +181,7 @@ class Thor
         FileUtils.mkdir_p(destination_root)
       end
 
-      if pretend
+      result = if pretend
         # In pretend mode, just yield down to the block
         block.arity == 1 ? yield(destination_root) : yield
       else
@@ -189,6 +191,7 @@ class Thor
 
       @destination_stack.pop
       shell.padding -= 1 if verbose
+      result
     end
 
     # Goes to the root and execute the given block.

--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -181,12 +181,13 @@ class Thor
         FileUtils.mkdir_p(destination_root)
       end
 
-      result = if pretend
+      result = nil
+      if pretend
         # In pretend mode, just yield down to the block
-        block.arity == 1 ? yield(destination_root) : yield
+        result = block.arity == 1 ? yield(destination_root) : yield
       else
         require "fileutils"
-        FileUtils.cd(destination_root) { block.arity == 1 ? yield(destination_root) : yield }
+        FileUtils.cd(destination_root) { result = block.arity == 1 ? yield(destination_root) : yield }
       end
 
       @destination_stack.pop

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -165,6 +165,10 @@ describe Thor::Actions do
       end
     end
 
+    it "returns the value yielded by the block" do
+      expect(runner.inside("foo") { 123 }).to eq(123)
+    end
+
     describe "when pretending" do
       it "no directories should be created" do
         runner.inside("bar", :pretend => true) {}

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -174,6 +174,10 @@ describe Thor::Actions do
         runner.inside("bar", :pretend => true) {}
         expect(File.exist?("bar")).to be false
       end
+
+      it "returns the value yielded by the block" do
+        expect(runner.inside("foo") { 123 }).to eq(123)
+      end
     end
 
     describe "when verbose" do


### PR DESCRIPTION
🌈
So that calling code can more conveniently inspect & use this value.

The value previously returned by this method doesn't seem useful so this seems like a safe change to make.

If this looks OK, should I also update the CHANGELOG?