### PR TITLE
 🌈 Allow options to be set back to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next
+* Enable options to be reset to default values after parsing.
+
 # 1.0.1
 * Fix thor when `thor/base` and `thor/group` are required without `thor.rb`.
 * Handle relative source path in `create_link`.

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -40,6 +40,7 @@ class Thor
         @assigns[key.to_s] = value
         @non_assigned_required.delete(hash_options[key])
       end
+      @default_values = @assigns.dup
 
       @shorts = {}
       @switches = {}
@@ -54,6 +55,10 @@ class Thor
           @shorts[name] ||= option.switch_name
         end
       end
+    end
+
+    def reset_options
+      @assigns = @default_values.dup
     end
 
     def remaining

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -308,6 +308,15 @@ describe Thor::Options do
         expect(parse("--foo=bar", "--foo", "12")["foo"]).to eq(["bar", "12"])
         expect(parse("--foo", "13", "--foo", "14")["foo"]).to eq(["bar", "12", "13", "14"])
       end
+
+      it "can reset parsed options back to defaults" do
+        create :foo => Thor::Option.new("foo", :type => :string, :repeatable => true)
+
+        expect(parse("--foo=bar", "--foo", "12")["foo"]).to eq(["bar", "12"])
+        @opt.reset_options
+        expect(parse("--foo=bar", "--foo", "12")["foo"]).to eq(["bar", "12"])
+        expect(parse("--foo", "13", "--foo", "14")["foo"]).to eq(["bar", "12", "13", "14"])
+      end
     end
 
     describe "with :boolean type" do


### PR DESCRIPTION
### Why do we need to be able to reset options?

#674 introduced a subtle bug that occurs if a Thor command is invoked multiple times during its lifetime (this will most likely only occur when running test suites). The failure mode in this case is that the previously parsed options are not cleared, and instead persisted to the next invocation of a Thor command.

For a concrete example: the [krane tests](https://github.com/Shopify/krane/blob/master/test/exe/deploy_test.rb#L51) were failing due to filename args being persisted and accumulated across tests.

The offending lines are [options.rb#L136-L140](https://github.com/erikhuda/thor/blob/master/lib/thor/parser/options.rb#L137), where we merge, instead of overwrite when `repeatable` is true.

The most straightforward solution seems to be adding this escape hatch that will reset options back to defaults and allow for reparsing from scratch. Let me know if that's a satisfactory approach.

An alternative solution could be to _always_ reset options back to defaults _every time `parse` is called_. I chose not to do this since the [existing test](https://github.com/erikhuda/thor/blob/master/spec/parser/options_spec.rb#L308) indicates that was not desired behaviour. This approach has the benefit of taking the onus off the caller to be mindful of clearing options.

- [x] I have added tests for this