### PR TITLE
Indent multiline messages in say_status

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -109,13 +109,14 @@ class Thor
       def say_status(status, message, log_status = true)
         return if quiet? || log_status == false
         spaces = "  " * (padding + 1)
-        color  = log_status.is_a?(Symbol) ? log_status : :green
-
         status = status.to_s.rjust(12)
+        margin = " " * status.length + spaces
+
+        color  = log_status.is_a?(Symbol) ? log_status : :green
         status = set_color status, color, true if color
 
-        buffer = "#{status}#{spaces}#{message}"
-        buffer = "#{buffer}\n" unless buffer.end_with?("\n")
+        message = message.to_s.chomp.gsub(/(?<!\A)^/, margin)
+        buffer = "#{status}#{spaces}#{message}\n"
 
         stdout.print(buffer)
         stdout.flush

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -186,6 +186,20 @@ describe Thor::Shell::Basic do
       shell.say_status(:create, "")
     end
 
+    it "indents a multiline message" do
+      status = :foobar
+      lines = ["first line", "second line", "  third line", "    fourth line"]
+
+      expect($stdout).to receive(:print) do |string|
+        formatted_status = string[/^\s*#{status}\s*/]
+        margin = " " * formatted_status.length
+
+        expect(string).to eq(formatted_status + lines.join("\n#{margin}") + "\n")
+      end
+
+      shell.say_status(status, lines.join("\n") + "\n")
+    end
+
     it "does not print a message if base is muted" do
       expect(shell).to receive(:mute?).and_return(true)
       expect($stdout).not_to receive(:print)


### PR DESCRIPTION
This prevents multiline status messages from breaking the left margin.

As an example, before this commit:

```
     status1  single line
     status2  multiline line 1
multiline line 2
multiline line 3
     status3  multiline indent 0
  multiline indent 2
    multiline indent 4
     status4  single line
```

And after this commit:

```
     status1  single line
     status2  multiline line 1
              multiline line 2
              multiline line 3
     status3  multiline indent 0
                multiline indent 2
                  multiline indent 4
     status4  single line
```

Closes rails/rails#38387.
