### PR TITLE
🌈 Need to dup default or else we have a troublesome alias

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -30,7 +30,12 @@ class Thor
 
       arguments.each do |argument|
         if !argument.default.nil?
-          @assigns[argument.human_name] = argument.default
+          begin
+            @assigns[argument.human_name] = argument.default.dup
+          rescue TypeError  # Compatibility shim for un-dup-able Fixnum in Ruby < 2.4
+            @assigns[argument.human_name] = argument.default
+            next
+          end
         elsif argument.required?
           @non_assigned_required << argument
         end

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -34,7 +34,6 @@ class Thor
             @assigns[argument.human_name] = argument.default.dup
           rescue TypeError  # Compatibility shim for un-dup-able Fixnum in Ruby < 2.4
             @assigns[argument.human_name] = argument.default
-            next
           end
         elsif argument.required?
           @non_assigned_required << argument

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -302,11 +302,10 @@ describe Thor::Options do
             "Expected '--fruit' to be one of #{enum.join(', ')}; got orange")
       end
 
-      it "allows multiple values if repeatable is specified" do
-        create :foo => Thor::Option.new("foo", :type => :string, :repeatable => true)
-
+      it "does not erroneously mutate defaults" do
+        create :foo => Thor::Option.new("foo", :type => :string, :repeatable => true, :required => false, :default => [])
         expect(parse("--foo=bar", "--foo", "12")["foo"]).to eq(["bar", "12"])
-        expect(parse("--foo", "13", "--foo", "14")["foo"]).to eq(["bar", "12", "13", "14"])
+        expect(@opt.instance_variable_get(:@switches)["--foo"].default).to eq([])
       end
     end
 


### PR DESCRIPTION
Following work on https://github.com/Shopify/krane/issues/697, I discovered a subtle bug that is now causing issues with the [repeatable flag feature](https://github.com/erikhuda/thor/pull/674).

If a default argument for a `Thor::Option | Thor::Argument` is provided, the option/argument constructor will call:
```
@assigns[argument.human_name] = argument.default
```
This aliases, __and does not create a copy of__, `argument.default` to `@assigns[argument.human_name]`. So now every time we update `@assigns`, we are also mutating `argument.default`. This was never a problem before because, without a repeatable flag, we'd never encounter a failure mode.

#### TODO
- [x] unit test