### PR TITLE
🌈 Update required rspec version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 group :test do
   gem "childlabor"
   gem "coveralls", ">= 0.8.19"
-  gem "rspec", ">= 3"
+  gem "rspec", ">= 3.2"
   gem "rspec-mocks", ">= 3"
   gem "rubocop", "~> 0.50.0"
   gem "simplecov", ">= 0.13"


### PR DESCRIPTION
Commit 693c2e91 introduced a dependency on `to_stderr_from_any_process`,
an API introduced in rspec 3.2.
