### PR TITLE
🌈 Fix readline specs

### DIFF
--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -2,8 +2,8 @@ class Thor
   module LineEditor
     class Readline < Basic
       def self.available?
-        @readline_reqd ||= begin
-            require "readline"
+        begin
+          require "readline"
         rescue LoadError
         end
 

--- a/lib/thor/line_editor/readline.rb
+++ b/lib/thor/line_editor/readline.rb
@@ -2,8 +2,8 @@ class Thor
   module LineEditor
     class Readline < Basic
       def self.available?
-        begin
-          require "readline"
+        @readline_reqd ||= begin
+            require "readline"
         rescue LoadError
         end
 

--- a/spec/line_editor/readline_spec.rb
+++ b/spec/line_editor/readline_spec.rb
@@ -2,6 +2,8 @@ require "helper"
 
 describe Thor::LineEditor::Readline do
   before do
+    # Eagerly check Readline availability and cache for this spec
+    Thor::LineEditor::Readline.available?
     unless defined? ::Readline
       ::Readline = double("Readline")
       allow(::Readline).to receive(:completion_append_character=).with(nil)

--- a/spec/line_editor/readline_spec.rb
+++ b/spec/line_editor/readline_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 describe Thor::LineEditor::Readline do
   before do
-    # Eagerly check Readline availability and cache for this spec
+    # Eagerly check Readline availability before mocking
     Thor::LineEditor::Readline.available?
     unless defined? ::Readline
       ::Readline = double("Readline")


### PR DESCRIPTION
An error was introduced in commit 7061b06fd87dc8b952f9072507ee991ee0a0858e
where readline specs fail because `require "readline"` is called after the
spec has established a mock `::Readline`. Prior to that change
`require "readline"` was always only called once.

This patch:
  * memoizes the `require` to ensure that it only happens once
  * leaves the `Object.const_defined?` check in place to keep tests simple
  * eagerly calls `available?` in the readline spec to match the original
    author's intent by requiring `readline` before the specs start.

This error wasn't caught by CI due to the bundler cache. You can see the failure caused by the earlier change by [removing the Bundler cache from Travis](https://travis-ci.org/bpo/thor/jobs/658865414)
