### PR TITLE
🌈 Fix another warning about $thor_runner

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -2,6 +2,7 @@ require "set"
 require_relative "thor/base"
 
 class Thor
+  $thor_runner ||= false
   class << self
     # Allows for custom "Command" package naming.
     #
@@ -398,7 +399,6 @@ class Thor
     # the namespace should be displayed as arguments.
     #
     def banner(command, namespace = nil, subcommand = false)
-      $thor_runner ||= false
       command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |formatted_usage|
         "#{basename} #{formatted_usage}"
       end.join("\n")

--- a/spec/fixtures/verbose.thor
+++ b/spec/fixtures/verbose.thor
@@ -5,6 +5,9 @@ $VERBOSE = true
 require 'thor'
 
 class Test < Thor
+  def self.exit_on_failure?
+    true
+  end
 end
 
 Test.start(ARGV)

--- a/spec/no_warnings_spec.rb
+++ b/spec/no_warnings_spec.rb
@@ -7,4 +7,10 @@ context "when $VERBOSE is enabled" do
 
     expect(err).to be_empty
   end
+
+  it "prints no warnings even when erroring" do
+    root = File.expand_path("..", __dir__)
+    _, err, = Open3.capture3("ruby -I #{root}/lib #{root}/spec/fixtures/verbose.thor noop")
+    expect(err).to_not match(/warning:/)
+  end
 end


### PR DESCRIPTION
Last patch for me today - this was what I was originally trying to do:

Previously `ruby -w`, when running an unknown command in Thor, a warning was
printed:

    thor-1.0.1/lib/thor/base.rb:514: warning: global variable `$thor_runner' not initialized

This was raised earlier in #633 but the fix was incomplete -- the global variable was being lazily defined in a method which is not the only entry point to Thor. This moves the global definition out to where the Thor class is defined.