### PR TITLE
🌈 Fixes a bug in the calculation of the print_wrapped method

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -230,8 +230,9 @@ class Thor
         paras = message.split("\n\n")
 
         paras.map! do |unwrapped|
-          counter = 0
-          unwrapped.split(" ").inject do |memo, word|
+          words = unwrapped.split(" ")
+          counter = words.first.length
+          words.inject do |memo, word|
             word = word.gsub(/\n\005/, "\n").gsub(/\005/, "\n")
             counter = 0 if word.include? "\n"
             if (counter + word.length + 1) < width

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -175,6 +175,46 @@ describe Thor::Shell::Basic do
     end
   end
 
+  describe "#print_wrapped" do
+    let(:message) do
+      "Creates a back-up of the given folder by compressing it in a .tar.gz\n"\
+      "file and then uploading it to the configured Amazon S3 Bucket.\n\n"\
+      "It does not verify the integrity of the generated back-up."
+    end
+
+    before do
+      allow(ENV).to receive(:[]).with("THOR_COLUMNS").and_return(80)
+    end
+
+    context "without indentation" do
+      subject(:wrap_text) { described_class.new.print_wrapped(message) }
+
+      let(:expected_output) do
+        "Creates a back-up of the given folder by compressing it in a .tar.gz file and\n"\
+        "then uploading it to the configured Amazon S3 Bucket.\n\n"\
+        "It does not verify the integrity of the generated back-up.\n"
+      end
+
+      it "properly wraps the text around the 80th column" do
+        expect { wrap_text }.to output(expected_output).to_stdout
+      end
+    end
+
+    context "with indentation" do
+      subject(:wrap_text) { described_class.new.print_wrapped(message, :indent => 4) }
+
+      let(:expected_output) do
+        "    Creates a back-up of the given folder by compressing it in a .tar.gz file\n"\
+        "    and then uploading it to the configured Amazon S3 Bucket.\n\n"\
+        "    It does not verify the integrity of the generated back-up.\n"
+      end
+
+      it "properly wraps the text around the 80th column" do
+        expect { wrap_text }.to output(expected_output).to_stdout
+      end
+    end
+  end
+
   describe "#say_status" do
     it "prints a message to the user with status" do
       expect($stdout).to receive(:print).with("      create  ~/.thor/command.thor\n")


### PR DESCRIPTION
# Description

This pull request fixes a bug that caused the `print_wrapped` method in the `Thor::Shell::Basic` class to incorrectly wrap the text when printing on the terminal. The reason for the bug is that the method assumes that the loop starts with the first word, when in fact it starts with the second word and the first word is already in the `memo` variable.

## Before the change:

![Screen Shot 2020-03-12 at 16 56 39](https://user-images.githubusercontent.com/1855186/76540579-9bc31180-6482-11ea-99ed-9ef9cd674830.png)

## After the change

![Screen Shot 2020-03-12 at 16 57 09](https://user-images.githubusercontent.com/1855186/76540594-a1b8f280-6482-11ea-83b3-e54c64dda772.png)

To see why this occurs you can run the following code on IRB or PRY:

```
>%w[hello world! how are you doing].inject { |memo, word| puts "#{memo} : #{word}"  }
hello : world!
 : how
 : are
 : you
 : doing
=> nil
```

As you can see the first iteration already has `"hello"` in `memo` and the first `word` is actually `"word!"`. The `print_wrapped` was not accounting for this and therefore given the right conditions the method would print beyond the edge of the terminal.