### PR TITLE
`remove_file` should unlink broken symlinks

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -329,7 +329,7 @@ class Thor
       path = File.expand_path(path, destination_root)
 
       say_status :remove, relative_to_original_destination_root(path), config.fetch(:verbose, true)
-      if !options[:pretend] && File.exist?(path)
+      if !options[:pretend] && (File.exist?(path) || File.symlink?(path))
         require "fileutils"
         ::FileUtils.rm_rf(path)
       end

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -259,6 +259,13 @@ describe Thor::Actions do
         expect(File.exist?(file)).to be false
       end
 
+      it "removes broken symlinks too" do
+        link_path = File.join(destination_root, "broken_symlink")
+        ::FileUtils.ln_s("invalid_reference", link_path)
+        action :remove_file, "broken_symlink"
+        expect(File.symlink?(link_path) || File.exist?(link_path)).to be false
+      end
+
       it "removes directories too" do
         action :remove_dir, "doc"
         expect(File.exist?(File.join(destination_root, "doc"))).to be false


### PR DESCRIPTION
The problem is that `remove_file` only checks if `File.exist?` which is false if the symlink target does not exist (anymore). In [`create_link`](https://github.com/erikhuda/thor/blob/34df888d721ecaa8cf0cea97d51dc6c388002742/lib/thor/actions/create_link.rb#L56) this was already considered.