### PR TITLE
Obey mute and options[:quiet] in Shell#say

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -94,6 +94,8 @@ class Thor
       # say("I know you knew that.")
       #
       def say(message = "", color = nil, force_new_line = (message.to_s !~ /( |\t)\Z/))
+        return if quiet?
+
         buffer = prepare_message(message, *color)
         buffer << "\n" if force_new_line && !message.to_s.end_with?("\n")
 

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -173,6 +173,21 @@ describe Thor::Shell::Basic do
       expect($stdout).to receive(:print).with("this_is_not_a_string\n")
       shell.say(:this_is_not_a_string, nil, true)
     end
+
+    it "does not print a message if muted" do
+      expect($stdout).not_to receive(:print)
+      shell.mute do
+        shell.say("Running...")
+      end
+    end
+
+    it "does not print a message if base is set to quiet" do
+      shell.base = MyCounter.new [1, 2]
+      expect(shell.base).to receive(:options).and_return(:quiet => true)
+
+      expect($stdout).not_to receive(:print)
+      shell.say("Running...")
+    end
   end
 
   describe "#print_wrapped" do


### PR DESCRIPTION
`Shell#say_status` already obeys `mute` and `options[:quiet]`.  This commit makes `Shell#say` obey them as well.