### PR TITLE
Use string interpolation for trailing whitespace

### DIFF
--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -321,7 +321,7 @@ TABLE
       2.times { @table.first.pop }
       content = capture(:stdout) { shell.print_table(@table) }
       expect(content).to eq(<<-TABLE)
-abc  
+abc#{"  "}
      #0    empty
 xyz  #786  last three
 TABLE


### PR DESCRIPTION
Code editors are commonly configured to strip trailing whitespace when saving.  Additionally, trailing whitespace may be hard to distinguish visually, both in the editor and in diffs.

This commit uses string interpolation to encode expected trailing whitespace.