### PR TITLE
Support `Thor::CoreExt::HashWithIndifferentAccess#except` for Rails 6.0

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -28,6 +28,12 @@ class Thor
         super(convert_key(key))
       end
 
+      def except(*keys)
+        dup.tap do |hash|
+          keys.each { |key| hash.delete(convert_key(key)) }
+        end
+      end
+
       def fetch(key, *args)
         super(convert_key(key), *args)
       end

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -14,6 +14,17 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.delete(:foo)).to eq("bar")
   end
 
+  it "supports except" do
+    unexcepted_hash = @hash.dup
+    @hash.except("foo")
+    expect(@hash).to eq(unexcepted_hash)
+
+    expect(@hash.except("foo")).to eq("baz" => "bee", "force" => true)
+    expect(@hash.except("foo", "baz")).to eq("force" => true)
+    expect(@hash.except(:foo)).to eq("baz" => "bee", "force" => true)
+    expect(@hash.except(:foo, :baz)).to eq("force" => true)
+  end
+
   it "supports fetch" do
     expect(@hash.fetch("foo")).to eq("bar")
     expect(@hash.fetch("foo", nil)).to eq("bar")


### PR DESCRIPTION
This PR supports `Thor::CoreExt::HashWithIndifferentAccess#except` and prevents breaking changes in Rails upgrades when using `options.except(:key)` in Thor task.

When Thor is used with Rails (Active Support), the behavior changes as follows.

## With Rails 5.2 or lower

```ruby
h = Thor::CoreExt::HashWithIndifferentAccess.new(foo: 1, bar: 2)
h.except(:foo) #=> {"bar"=>2}
```

## With Rails 6.0

```ruby
h = Thor::CoreExt::HashWithIndifferentAccess.new(foo: 1, bar: 2)
h.except(:foo) #=> {"foo"=>1, "bar"=>2}
```

This difference behavior is due to the following changes in Rails 6.0.
https://github.com/rails/rails/pull/35771

This PR makes the behavior between Rails 5.2 and Rails 6.0 compatible.