### PR TITLE
Check for duplicate content in relevant section when inserting into files

### DIFF
--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -108,7 +108,10 @@ class Thor
       def replace!(regexp, string, force)
         return if pretend?
         content = File.read(destination)
-        if force || !content.include?(replacement)
+        before, after = content.split(regexp, 2)
+        snippet = (behavior == :after ? after : before).to_s
+
+        if force || !snippet.include?(replacement)
           success = content.gsub!(regexp, string)
 
           File.open(destination, "wb") { |file| file.write(content) }

--- a/spec/actions/inject_into_file_spec.rb
+++ b/spec/actions/inject_into_file_spec.rb
@@ -34,9 +34,19 @@ describe Thor::Actions::InjectIntoFile do
       expect(File.read(file)).to eq("__start__\nmore content\nREADME\n__end__\n")
     end
 
+    it "ignores duplicates before the after flag" do
+      invoke! "doc/README", "\nREADME", :after => "README"
+      expect(File.read(file)).to eq("__start__\nREADME\nREADME\n__end__\n")
+    end
+
     it "changes the file adding content before the flag" do
       invoke! "doc/README", "more content\n", :before => "__end__"
       expect(File.read(file)).to eq("__start__\nREADME\nmore content\n__end__\n")
+    end
+
+    it "ignores duplicates before the before flag" do
+      invoke! "doc/README", "README\n", :before => "README"
+      expect(File.read(file)).to eq("__start__\nREADME\nREADME\n__end__\n")
     end
 
     it "appends content to the file if before and after arguments not provided" do


### PR DESCRIPTION
I ran into some unexpected behavior today with `insert_into_file`. I was trying to insert `, null: false` into a migration after some text, but nothing happened. 

```ruby
  t.belongs_to :recipient, null: false
  t.string :type
````

```ruby
insert_into_file path, ", null: false", after: "t.string :type"
```

This does nothing because `, null: false` exists in the file (anywhere).

Using `after:` I would expect `insert_into_file` to only care if the string exists _after_ the matching line, not before it.

This PR would change the behavior to only look through the before or after portions of the file content to make it more intuitive.