### PR TITLE
Use URI.send in apply action to work in Ruby 3

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -219,7 +219,7 @@ class Thor
 
       contents = if is_uri
         require "open-uri"
-        open(path, "Accept" => "application/x-thor-template", &:read)
+        URI.send(:open, path, "Accept" => "application/x-thor-template", &:read)
       else
         open(path, &:read)
       end


### PR DESCRIPTION
In Ruby 3.0.0-rc1, I get the error `No such file or directory @ rb_sysopen` when using the `apply` action with a remote URL. By changing the use of `open` to `URI.send(:open …)`, it works in Ruby 3 while preserving backwards-compatibility (this is already how it's done in the `get` file manipulation method).