### PR TITLE
🌈 Replace `set` usages with arrays

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -1,4 +1,3 @@
-require "set"
 require_relative "thor/base"
 
 class Thor
@@ -324,7 +323,7 @@ class Thor
     # ==== Parameters
     # Symbol ...:: A list of commands that should be affected.
     def stop_on_unknown_option!(*command_names)
-      stop_on_unknown_option.merge(command_names)
+      @stop_on_unknown_option = stop_on_unknown_option | command_names
     end
 
     def stop_on_unknown_option?(command) #:nodoc:
@@ -338,7 +337,7 @@ class Thor
     # ==== Parameters
     # Symbol ...:: A list of commands that should be affected.
     def disable_required_check!(*command_names)
-      disable_required_check.merge(command_names)
+      @disable_required_check = disable_required_check | command_names
     end
 
     def disable_required_check?(command) #:nodoc:
@@ -348,12 +347,12 @@ class Thor
   protected
 
     def stop_on_unknown_option #:nodoc:
-      @stop_on_unknown_option ||= Set.new
+      @stop_on_unknown_option ||= []
     end
 
     # help command has the required check disabled by default.
     def disable_required_check #:nodoc:
-      @disable_required_check ||= Set.new([:help])
+      @disable_required_check ||= [:help]
     end
 
     # The method responsible for dispatching given the args.


### PR DESCRIPTION
Set has been gemified as of ruby 3.0.0. Since `bundler` vendors `thor` internally, it's helpful for `bundler` that `thor` doesn't use `set`, so that `bundler` doesn't activate the gem `set` too early and final users can still specify whichever version of `set` they want in their Gemfiles.