### PR TITLE
🌈The klass parameter 'inject_into_class' should be given a string type.(also inject_into_module)

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -210,9 +210,9 @@ class Thor
     #
     # ==== Examples
     #
-    #   inject_into_class "app/controllers/application_controller.rb", ApplicationController, "  filter_parameter :password\n"
+    #   inject_into_class "app/controllers/application_controller.rb", "ApplicationController", "  filter_parameter :password\n"
     #
-    #   inject_into_class "app/controllers/application_controller.rb", ApplicationController do
+    #   inject_into_class "app/controllers/application_controller.rb", "ApplicationController" do
     #     "  filter_parameter :password\n"
     #   end
     #
@@ -233,9 +233,9 @@ class Thor
     #
     # ==== Examples
     #
-    #   inject_into_module "app/helpers/application_helper.rb", ApplicationHelper, "  def help; 'help'; end\n"
+    #   inject_into_module "app/helpers/application_helper.rb", "ApplicationHelper", "  def help; 'help'; end\n"
     #
-    #   inject_into_module "app/helpers/application_helper.rb", ApplicationHelper do
+    #   inject_into_module "app/helpers/application_helper.rb", "ApplicationHelper" do
     #     "  def help; 'help'; end\n"
     #   end
     #

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -1,8 +1,5 @@
 require "helper"
 
-class Application; end
-module ApplicationHelper; end
-
 describe Thor::Actions do
   def runner(options = {}, behavior = :invoke)
     @runner ||= MyCounter.new([1], options, :destination_root => destination_root, :behavior => behavior)
@@ -407,17 +404,17 @@ describe Thor::Actions do
       end
 
       it "appends content to a class" do
-        action :inject_into_class, "application.rb", Application, "  filter_parameters :password\n"
+        action :inject_into_class, "application.rb", "Application", "  filter_parameters :password\n"
         expect(File.binread(file)).to eq("class Application < Base\n  filter_parameters :password\nend\n")
       end
 
       it "accepts a block" do
-        action(:inject_into_class, "application.rb", Application) { "  filter_parameters :password\n" }
+        action(:inject_into_class, "application.rb", "Application") { "  filter_parameters :password\n" }
         expect(File.binread(file)).to eq("class Application < Base\n  filter_parameters :password\nend\n")
       end
 
       it "logs status" do
-        expect(action(:inject_into_class, "application.rb", Application, "  filter_parameters :password\n")).to eq("      insert  application.rb\n")
+        expect(action(:inject_into_class, "application.rb", "Application", "  filter_parameters :password\n")).to eq("      insert  application.rb\n")
       end
 
       it "does not append if class name does not match" do
@@ -432,17 +429,17 @@ describe Thor::Actions do
       end
 
       it "appends content to a module" do
-        action :inject_into_module, "application_helper.rb", ApplicationHelper, "  def help; 'help'; end\n"
+        action :inject_into_module, "application_helper.rb", "ApplicationHelper", "  def help; 'help'; end\n"
         expect(File.binread(file)).to eq("module ApplicationHelper\n  def help; 'help'; end\nend\n")
       end
 
       it "accepts a block" do
-        action(:inject_into_module, "application_helper.rb", ApplicationHelper) { "  def help; 'help'; end\n" }
+        action(:inject_into_module, "application_helper.rb", "ApplicationHelper") { "  def help; 'help'; end\n" }
         expect(File.binread(file)).to eq("module ApplicationHelper\n  def help; 'help'; end\nend\n")
       end
 
       it "logs status" do
-        expect(action(:inject_into_module, "application_helper.rb", ApplicationHelper, "  def help; 'help'; end\n")).to eq("      insert  application_helper.rb\n")
+        expect(action(:inject_into_module, "application_helper.rb", "ApplicationHelper", "  def help; 'help'; end\n")).to eq("      insert  application_helper.rb\n")
       end
 
       it "does not append if module name does not match" do


### PR DESCRIPTION
I think that in most cases the target klass is not defined in a file that uses inject_into_class.
So it is more friendly to set the default comment to string type.
as-is
```
inject_into_class "xxx.rb", ApplicationController, "Lorem"
```

to-be
```
inject_into_class "xxx.rb", "ApplicationController", "Lorem"
```

I think it's more realistic for test specs to delete the empty class definition in the first line.
Also about the inject_into_module.