### PR TITLE
Repeatable hash type flags bugfix.

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -149,9 +149,7 @@ class Thor
   protected
 
     def assign_result!(option, result)
-      if option.repeatable && option.type == :hash
-        (@assigns[option.human_name] ||= {}).merge!(result)
-      elsif option.repeatable
+      if option.repeatable
         (@assigns[option.human_name] ||= []) << result
       else
         @assigns[option.human_name] = result

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -417,7 +417,7 @@ describe Thor::Options do
 
       it "allows multiple values if repeatable is specified" do
         create :attributes => Thor::Option.new("attributes", :type => :hash, :repeatable => true)
-        expect(parse("--attributes", "name:one", "foo:1", "--attributes", "name:two", "bar:2")["attributes"]).to eq({"name"=>"two", "foo"=>"1", "bar" => "2"})
+        expect(parse("--attributes", "name:one", "foo:1", "--attributes", "name:two", "bar:2")["attributes"]).to eq([{"name"=>"one", "foo"=>"1"}, {"name"=>"two", "bar" => "2"}])
       end
     end
 


### PR DESCRIPTION
They treated like every other type now. Instead of merging each key/val
into a hash, each flag is treated like it's own hash that should be put
into an array.

fixes #768

:rainbow: 