### PR TITLE
fix encoding error when running a merge tool

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -367,7 +367,7 @@ class Thor
 
       def merge(destination, content) #:nodoc:
         require "tempfile"
-        Tempfile.open([File.basename(destination), File.extname(destination)], File.dirname(destination)) do |temp|
+        Tempfile.open([File.basename(destination), File.extname(destination)], File.dirname(destination), binmode: true) do |temp|
           temp.write content
           temp.rewind
           system(*merge_tool, temp.path, destination)

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -104,6 +104,28 @@ describe Thor::Actions do
       end
     end
 
+    it "launches the merge tool when there is a collision and source has utf-8 characters" do
+      previous_internal = Encoding.default_internal
+
+      silence_warnings do
+        Encoding.default_internal = Encoding::UTF_8
+      end
+
+      destination = File.join(destination_root, "encoding_with_utf8.thor")
+      FileUtils.mkdir_p(destination_root)
+
+      File.write(destination, "blabla")
+
+      allow(runner.shell).to receive(:merge_tool).and_return("meld")
+      expect(Thor::LineEditor).to receive(:readline).and_return("m")
+      expect(runner.shell).to receive(:system).with("meld", /encoding_with_utf8.thor/, /encoding_with_utf8.thor/)
+      action :copy_file, "encoding_with_utf8.thor"
+    ensure
+      silence_warnings do
+        Encoding.default_internal = previous_internal
+      end
+    end
+
     it "logs status" do
       expect(action(:copy_file, "command.thor")).to eq("      create  command.thor\n")
     end


### PR DESCRIPTION
This solves essentially the same problem as #898 but for when a merge tool is requested in case of a collision.