### PR TITLE
Suppress false positive warnings from gem-defined methods

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -575,13 +575,21 @@ class Thor
       elsif all_commands[meth] || meth == "method_missing"
         true
       else
-        puts "[WARNING] Attempted to create command #{meth.inspect} without usage or description. " \
-             "Call desc if you want this method to be available as command or declare it inside a " \
-             "no_commands{} block. Invoked from #{caller[1].inspect}."
+        unless defined_in_gem?(meth)
+          puts "[WARNING] Attempted to create command #{meth.inspect} without usage or description. " \
+               "Call desc if you want this method to be available as command or declare it inside a " \
+               "no_commands{} block. Invoked from #{caller[1].inspect}."
+        end
         false
       end
     end
     alias_method :create_task, :create_command
+
+    def defined_in_gem?(meth) #:nodoc:
+      source_file = public_instance_method(meth.to_sym).source_location&.first
+      return false unless source_file
+      Gem.path.any? { |path| source_file.start_with?(path) }
+    end
 
     def initialize_added #:nodoc:
       class_options.merge!(method_options)

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -575,20 +575,20 @@ class Thor
       elsif all_commands[meth] || meth == "method_missing"
         true
       else
-        unless defined_in_gem?(meth)
+        caller_line = caller[1]
+        unless defined_in_gem?(caller_line)
           puts "[WARNING] Attempted to create command #{meth.inspect} without usage or description. " \
                "Call desc if you want this method to be available as command or declare it inside a " \
-               "no_commands{} block. Invoked from #{caller[1].inspect}."
+               "no_commands{} block. Invoked from #{caller_line.inspect}."
         end
         false
       end
     end
     alias_method :create_task, :create_command
 
-    def defined_in_gem?(meth) #:nodoc:
-      source_file = public_instance_method(meth.to_sym).source_location&.first
-      return false unless source_file
-      Gem.path.any? { |path| source_file.start_with?(path) }
+    def defined_in_gem?(caller_line) #:nodoc:
+      return false unless caller_line
+      Gem.path.any? { |path| caller_line.include?(path) }
     end
 
     def initialize_added #:nodoc:

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -748,6 +748,15 @@ HELP
         klass.class_eval "def help; end"
       end).to be_empty
     end
+
+    it "does not print if a method is defined by code in an installed gem" do
+      klass = Class.new(Thor)
+      allow(klass).to receive(:defined_in_gem?).and_return(true)
+
+      expect(capture(:stdout) do
+        klass.class_eval "def some_gem_method; end"
+      end).to be_empty
+    end
   end
 
   describe "edge-cases" do


### PR DESCRIPTION
🌈

### Problem

When using mocking frameworks like `rspec-mocks` with classes inheriting from `Thor`, `method_added` fires for every method the framework dynamically defines. Since these methods have no `desc` and are not in a `no_commands` block, `create_command` emits a warning about attempting to create a command "without usage or description". As these are not user-defined methods, these warnings are false positives which can produce noisy test outputs which make test results harder to read, and may obscure genuine warnings.

I believe it is useful to display these warnings in specs when they are genuine, as the test may be the only feedback the developer gets before merging to `main`.

I think the solution should therefore meet the following constraints:
1. Genuine developer failure to add `desc` or `no_commands` should display the relevant warning when the relevant tests run
2. False positives, e.g., from RSpec mocks, should not be displayed when the relevant tests run
3. It should be framework agnostic; I encountered the issue through `rspec-mocks`, but it could be triggered other ways

### Reproduction

```ruby
# Gemfile
source "https://rubygems.org"

gem "thor"
gem "rspec"
```

```ruby
# lib/my_cli.rb
require "thor"

class MyCli < Thor
  desc "greet NAME", "Say hello to NAME"
  def greet(name)
    puts formatter.call(name)
  end

  no_commands do
    def formatter
      ->(name) { "Hello, #{name}!" }
    end
  end
end
```

```ruby
# spec/my_cli_spec.rb
require_relative "../lib/my_cli"

RSpec.describe MyCli do
  before do
    allow_any_instance_of(described_class).to receive(:formatter).and_return(
      ->(name) { "Hello, #{name}!" }
    )
  end
  
  it "greets by name" do
    expect { MyCli.start(%w[greet World]) }.to output("Hello, World!\n").to_stdout
  end
end
```

```
$ bundle install
$ bundle exec rspec spec/my_cli_spec.rb
```

Output:

```
[WARNING] Attempted to create command "__formatter_without_any_instance__" without usage or description. Call desc if you want this method to be available as command or declare it inside a no_commands{} block. Invoked from "$HOME/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/rspec-mocks-3.13.8/lib/rspec/mocks/any_instance/recorder.rb:241:in 'Module#alias_method'".
[WARNING] Attempted to create command "formatter" without usage or description. Call desc if you want this method to be available as command or declare it inside a no_commands{} block. Invoked from "$HOME/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/rspec-mocks-3.13.8/lib/rspec/mocks/any_instance/recorder.rb:263:in 'Module#define_method'".
[WARNING] Attempted to create command "formatter" without usage or description. Call desc if you want this method to be available as command or declare it inside a no_commands{} block. Invoked from "$HOME/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/rspec-mocks-3.13.8/lib/rspec/mocks/any_instance/recorder.rb:223:in 'Module#alias_method'".
.

Finished in 0.00574 seconds (files took 0.03754 seconds to load)
1 example, 0 failures
```

The method is correctly declared inside a `no_commands` block, but `rspec-mocks` redefines it with `define_method` to set up the stub, which re-triggers `method_added` outside the `no_commands` context. In a real test suite with many mocked methods, these warnings multiply and can be very noisy.

### Solution

This change checks the `caller` against `Gem.path` to detect whether a method was defined by code inside an installed gem, and skips the warning if it was. If the violation occurs inside an installed gem, then this is not a developer mistake and is almost certainly a gem doing something dynamic.
