### PR TITLE
ci: add permissions: contents: read to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Run tests
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
**What:** add `permissions: contents: read` to `.github/workflows/tests.yml`.

**Why:** the test workflow doesn't write to the repo. Declaring the minimum scope is what GitHub recommends ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)) and what OpenSSF Scorecard's `Token-Permissions` check expects.

**Why now:** tj-actions/changed-files (CVE-2025-30066) showed how cheap an explicit `permissions:` block is relative to the cost of a leaked write-scoped token.

**Risk of this change:** none observed locally. The token scope is being tightened, not loosened, so the only failure mode would be a step that secretly needed a write scope - which would have to be added back explicitly with a clear justification. YAML still parses (`yaml.safe_load`).
