### PR TITLE
Disable required check for tree and skip check_at_least_one! if disable_required_check

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -474,7 +474,7 @@ class Thor
       @stop_on_unknown_option ||= []
     end
 
-    # help command has the required check disabled by default.
+    # help and tree commands have the required check disabled by default.
     def disable_required_check #:nodoc:
       @disable_required_check ||= [:help, :tree]
     end

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -476,7 +476,7 @@ class Thor
 
     # help command has the required check disabled by default.
     def disable_required_check #:nodoc:
-      @disable_required_check ||= [:help]
+      @disable_required_check ||= [:help, :tree]
     end
 
     def print_exclusive_options(shell, command = nil) # :nodoc:

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -134,7 +134,7 @@ class Thor
 
       check_requirement! unless @disable_required_check
       check_exclusive!
-      check_at_least_one!
+      check_at_least_one! unless @disable_required_check
 
       assigns = Thor::CoreExt::HashWithIndifferentAccess.new(@assigns)
       assigns.freeze


### PR DESCRIPTION
🌈

### Problems
1. `tree` command does not have the required check disabled by default. The purpose of tree is to reveal the structure of the CLI and I feel we should not need to pass required arguments, which will be redundant in this context, for it to work.
2. `check_at_least_one!` runs when parsing commands for which `disable_required_check` has been set. I take it that at least one is a disjunctive form of `required`. This means that if I have set `class_at_least_one :foo, :bar` then `my_cli help` will not work as intended; we must pass either `foo` or `bar` to the `help` command.

### Reproduction
```ruby
# Gemfile
source "https://rubygems.org"

gem "thor"
```

```ruby
# lib/my_cli.rb
require "thor"

class MyCli < Thor
  class_option :account, type: :string, required: true
  class_option :admin, type: :boolean
  class_option :user, type: :boolean
  class_at_least_one :admin, :user

  default_task :auth

  desc "auth", "Authorize the user"
  def auth
    puts "Authorizing user with role: #{role} for account: #{account}"
  end

  def self.exit_on_failure?
    true
  end

  private

  def role
    if options[:admin]
      "admin"
    elsif options[:user]
      "user"
    end
  end

  def account
    options[:account]
  end
end

MyCli.start if __FILE__ == $PROGRAM_NAME
```

```
$ bundle install
```

#### Problem One
```
$ bundle exec ruby lib/my_cli.rb tree
```
Output:
```
No value provided for required options '--account'
```

#### Problem Two
```
$ bundle exec ruby lib/my_cli.rb help
```
Output:
```
Not found at least one of required options '--admin', '--user'
```

### Solution
1. Update `disable_required_check` to include `:tree` in default array assigned to `@disable_required_check`
2. Update `parse` to skip `check_at_least_one!` validation when `@disable_required_check`