### PR TITLE
Ensure command passes required relations to fix NoMethodError on mistyped commands 

### DIFF
--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -3,7 +3,9 @@ class Thor
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
     def initialize(name, description, long_description, wrap_long_description, usage, options = nil, options_relation = nil)
-      super(name.to_s, description, long_description, wrap_long_description, usage, options || {}, options_relation || {})
+      options_relation = options_relation_with_defaults(options_relation)
+
+      super(name.to_s, description, long_description, wrap_long_description, usage, options || {}, options_relation)
     end
 
     def initialize_copy(other) #:nodoc:
@@ -64,14 +66,25 @@ class Thor
     end
 
     def method_exclusive_option_names #:nodoc:
-      self.options_relation[:exclusive_option_names] || []
+      self.options_relation[:exclusive_option_names]
     end
 
     def method_at_least_one_option_names #:nodoc:
-      self.options_relation[:at_least_one_option_names] || []
+      self.options_relation[:at_least_one_option_names]
     end
 
   protected
+
+  def options_relation_with_defaults(relations)
+    default_options_relation.merge(relations || {})
+  end
+
+  def default_options_relation
+    {
+      exclusive_option_names: [],
+      at_least_one_option_names: []
+    }
+  end
 
     # Add usage with required arguments
     def required_arguments_for(klass, usage)

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -43,6 +43,7 @@ describe Thor::Command do
       expect(Thor::DynamicCommand.new("command").description).to eq("A dynamically-generated command")
       expect(Thor::DynamicCommand.new("command").usage).to eq("command")
       expect(Thor::DynamicCommand.new("command").options).to eq({})
+      expect(Thor::DynamicCommand.new("command").options_relation).to eq(exclusive_option_names: [], at_least_one_option_names: [])
     end
 
     it "does not invoke an existing method" do


### PR DESCRIPTION
🌈

## Problem

`DynamicCommand` [does not pass](https://github.com/rails/thor/blob/main/lib/thor/command.rb#L139) `options_relation` to the constructor. This means that attempts to key into the relations hash [here](https://github.com/rails/thor/blob/main/lib/thor/base.rb#L89-L90) raise `NoMethodError` when `class_exclusive` has been set. The same issue surfaces with `class_at_least_one`, so long as one of the required arguments is passed.

I take it that the desired behaviour in both cases is for it to output something like the following:
```
Could not find command "helo".
Did you mean?  "hello"
               "help"
```

## Reproduction

```ruby
# Gemfile
source "https://rubygems.org"

gem "thor", "~> 1.5"
```

```
$ bundle install
```

### Scenario One
```ruby
# cli.rb

# frozen_string_literal: true

require "thor"

class Cli < Thor
  class_option :quiet, type: :boolean
  class_option :verbose, type: :boolean
  class_exclusive :quiet, :verbose

  desc "hello", "Say hello"
  def hello
    puts "Hello"
  end

  def self.exit_on_failure? = true
end

Cli.start(ARGV)
```

```
$ bundle exec ruby cli.rb helo
```

Output:
```
$HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:89:in 'block in Thor::Base#initialize': undefined method '<<' for nil (NoMethodError)

      self.class.class_exclusive_option_names.map { |n| relations[:exclusive_option_names] << n }
                                                                                           ^^
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:89:in 'Array#map'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:89:in 'Thor::Base#initialize'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/invocation.rb:26:in 'Thor::Invocation#initialize'
        from$HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/shell.rb:45:in 'Thor::Shell#initialize'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor.rb:534:in 'Thor.dispatch'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:585:in 'Thor::Base::ClassMethods#start'
        from cli.rb:18:in '<main>'
```

### Scenario Two
```ruby
# frozen_string_literal: true

require "thor"

class Cli < Thor
  class_option :quiet, type: :boolean
  class_option :verbose, type: :boolean
  class_at_least_one :quiet, :verbose

  desc "hello", "Say hello"
  def hello
    puts "Hello"
  end

  def self.exit_on_failure? = true
end

Cli.start(ARGV)
```

```
$ bundle exec ruby cli.rb helo --quiet
```

Output:
```
$HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:90:in 'block in Thor::Base#initialize': undefined method '<<' for nil (NoMethodError)

      self.class.class_at_least_one_option_names.map { |n| relations[:at_least_one_option_names] << n }
                                                                                                 ^^
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:90:in 'Array#map'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:90:in 'Thor::Base#initialize'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/invocation.rb:26:in 'Thor::Invocation#initialize'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/shell.rb:45:in 'Thor::Shell#initialize'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor.rb:534:in 'Thor.dispatch'
        from $HOME/.local/share/mise/installs/ruby/4.0.5/lib/ruby/gems/4.0.0/gems/thor-1.5.0/lib/thor/base.rb:585:in 'Thor::Base::ClassMethods#start'
        from cli.rb:18:in '<main>'
```

## Solution
Ensure that `Command` class always populates `options_relation` with an empty array value for `exclusive_option_names`, `at_least_one_option_names` if the key is missing in the initial input, before calling `super`.

We could just have `DynamicCommand` pass these directly to `super`, but enforcing it in the `Command` class seemed to be the more robust solution as it would prevent the issue in any future subclasses.